### PR TITLE
Add zoom indicator and controls panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 
 - Add touch gesture support for pan and zoom (pinch-to-zoom and single-finger pan for mobile/tablet).
 - Add zoom indicator showing current zoom percentage when zoomed or panned.
+- Add zoom in/out buttons to the view action bar for precise zoom control.
 
 ## 0.3.0 - 2026-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Add zoom indicator showing current zoom percentage when zoomed or panned.
+- Add zoom in/out buttons to the view action bar for precise zoom control.
+
 ## 0.3.2 - 2026-01-29
 
 ### Changed
@@ -13,8 +20,6 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 ### Added
 
 - Add touch gesture support for pan and zoom (pinch-to-zoom and single-finger pan for mobile/tablet).
-- Add zoom indicator showing current zoom percentage when zoomed or panned.
-- Add zoom in/out buttons to the view action bar for precise zoom control.
 
 ## 0.3.0 - 2026-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 ### Added
 
 - Add touch gesture support for pan and zoom (pinch-to-zoom and single-finger pan for mobile/tablet).
+- Add zoom indicator showing current zoom percentage when zoomed or panned.
 
 ## 0.3.0 - 2026-01-17
 

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -436,7 +436,7 @@ export class MermaidView extends TextFileView {
 			cls: "mermaid-zoom-control-item",
 			attr: { "aria-label": "Reset zoom" },
 		});
-		setIcon(resetBtn, "maximize");
+		setIcon(resetBtn, "rotate-cw");
 		resetBtn.addEventListener("click", () => this.resetZoom());
 
 		const zoomOutBtn = zoomGroup.createDiv({

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -139,10 +139,8 @@ export class MermaidView extends TextFileView {
 			this.toggleMode();
 		});
 
-		// Add reset zoom button
-		this.addAction("maximize", "Reset zoom", () => {
-			this.resetZoom();
-		});
+		// Create zoom controls panel on the right side
+		this.createZoomControls();
 
 		// Set initial mode
 		this.setMode("preview");
@@ -421,10 +419,65 @@ export class MermaidView extends TextFileView {
 		}
 	}
 
+	private createZoomControls(): void {
+		const controls = this.previewEl.createDiv({ cls: "mermaid-zoom-controls" });
+
+		// Zoom control group
+		const zoomGroup = controls.createDiv({ cls: "mermaid-zoom-control-group" });
+
+		const zoomInBtn = zoomGroup.createDiv({
+			cls: "mermaid-zoom-control-item",
+			attr: { "aria-label": "Zoom in" },
+		});
+		setIcon(zoomInBtn, "plus");
+		zoomInBtn.addEventListener("click", () => this.zoomIn());
+
+		const resetBtn = zoomGroup.createDiv({
+			cls: "mermaid-zoom-control-item",
+			attr: { "aria-label": "Reset zoom" },
+		});
+		setIcon(resetBtn, "maximize");
+		resetBtn.addEventListener("click", () => this.resetZoom());
+
+		const zoomOutBtn = zoomGroup.createDiv({
+			cls: "mermaid-zoom-control-item",
+			attr: { "aria-label": "Zoom out" },
+		});
+		setIcon(zoomOutBtn, "minus");
+		zoomOutBtn.addEventListener("click", () => this.zoomOut());
+	}
+
 	private resetZoom(): void {
 		this.scale = 1;
 		this.translateX = 0;
 		this.translateY = 0;
+		this.applyTransform();
+	}
+
+	private zoomIn(): void {
+		this.zoomToCenter(1.2);
+	}
+
+	private zoomOut(): void {
+		this.zoomToCenter(0.8);
+	}
+
+	private zoomToCenter(factor: number): void {
+		const newScale = Math.min(
+			this.MAX_SCALE,
+			Math.max(this.MIN_SCALE, this.scale * factor)
+		);
+
+		// Zoom toward center of preview area
+		const rect = this.previewEl.getBoundingClientRect();
+		const centerX = rect.width / 2;
+		const centerY = rect.height / 2;
+
+		const scaleChange = newScale / this.scale;
+		this.translateX = centerX - scaleChange * (centerX - this.translateX);
+		this.translateY = centerY - scaleChange * (centerY - this.translateY);
+		this.scale = newScale;
+
 		this.applyTransform();
 	}
 }

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -35,6 +35,9 @@ export class MermaidView extends TextFileView {
 	private initialPinchDistance = 0;
 	private initialPinchScale = 1;
 
+	// Zoom indicator
+	private zoomIndicator: HTMLElement;
+
 	// Debounce timer for live preview
 	private renderDebounceTimer: number | null = null;
 	private readonly RENDER_DEBOUNCE_MS = 300;
@@ -67,6 +70,12 @@ export class MermaidView extends TextFileView {
 
 		// Create zoom wrapper inside preview
 		this.zoomWrapper = this.previewEl.createDiv({ cls: "mermaid-zoom-wrapper" });
+
+		// Create zoom indicator
+		this.zoomIndicator = this.previewEl.createDiv({
+			cls: "mermaid-zoom-indicator",
+			text: "100%",
+		});
 
 		// Set up pan/zoom event handlers
 		this.setupPanZoom();
@@ -397,6 +406,19 @@ export class MermaidView extends TextFileView {
 
 	private applyTransform(): void {
 		this.zoomWrapper.style.transform = `translate(${this.translateX}px, ${this.translateY}px) scale(${this.scale})`;
+		this.updateZoomIndicator();
+	}
+
+	private updateZoomIndicator(): void {
+		const percentage = Math.round(this.scale * 100);
+		this.zoomIndicator.textContent = `${percentage}%`;
+
+		// Show/hide based on whether zoom is at default
+		if (this.scale === 1 && this.translateX === 0 && this.translateY === 0) {
+			this.zoomIndicator.removeClass("mermaid-zoom-indicator-active");
+		} else {
+			this.zoomIndicator.addClass("mermaid-zoom-indicator-active");
+		}
 	}
 
 	private resetZoom(): void {

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,7 @@
 	justify-content: center;
 	box-sizing: border-box;
 	cursor: grab;
+	position: relative;
 }
 
 .mermaid-view-preview.mermaid-view-panning {
@@ -64,6 +65,27 @@
 .mermaid-zoom-wrapper {
 	transform-origin: 0 0;
 	will-change: transform;
+}
+
+/* Zoom indicator */
+.mermaid-zoom-indicator {
+	position: absolute;
+	bottom: 12px;
+	right: 12px;
+	padding: 4px 8px;
+	background-color: var(--background-secondary);
+	border-radius: var(--radius-s);
+	font-size: var(--font-smaller);
+	font-family: var(--font-monospace);
+	color: var(--text-muted);
+	opacity: 0;
+	transition: opacity 150ms ease-in-out;
+	pointer-events: none;
+	z-index: 10;
+}
+
+.mermaid-zoom-indicator.mermaid-zoom-indicator-active {
+	opacity: 1;
 }
 
 .mermaid-view-preview .mermaid {

--- a/styles.css
+++ b/styles.css
@@ -67,11 +67,58 @@
 	will-change: transform;
 }
 
+/* Zoom controls panel - matches Canvas styling */
+.mermaid-zoom-controls {
+	position: absolute;
+	inset-inline-end: var(--size-4-2);
+	top: var(--size-4-2);
+	display: flex;
+	flex-direction: column;
+	z-index: 10;
+}
+
+.mermaid-zoom-control-group {
+	border-radius: var(--radius-s);
+	background-color: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	overflow: hidden;
+}
+
+.mermaid-zoom-control-item {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: var(--size-4-2);
+	border-radius: 0;
+	box-shadow: none;
+	cursor: pointer;
+	border-bottom: 1px solid var(--background-modifier-border);
+	color: var(--text-muted);
+	--icon-size: var(--icon-s);
+	--icon-stroke: var(--icon-s-stroke-width);
+}
+
+.mermaid-zoom-control-item:last-child {
+	border-bottom: none;
+}
+
+.mermaid-zoom-control-item:hover {
+	color: var(--text-normal);
+	background-color: var(--interactive-hover);
+}
+
+.mermaid-zoom-control-item svg {
+	width: var(--icon-size);
+	height: var(--icon-size);
+	stroke-width: var(--icon-stroke);
+}
+
 /* Zoom indicator */
 .mermaid-zoom-indicator {
 	position: absolute;
 	bottom: 12px;
-	right: 12px;
+	left: 50%;
+	transform: translateX(-50%);
 	padding: 4px 8px;
 	background-color: var(--background-secondary);
 	border-radius: var(--radius-s);


### PR DESCRIPTION
This PR improves the zoom/pan experience by adding visual feedback and dedicated controls.

The zoom indicator displays the current zoom percentage in the bottom center when the diagram is zoomed or panned, providing clear feedback on the current view state.

A floating control panel on the right side offers zoom in, reset, and zoom out buttons, styled to match Obsidian's Canvas controls for a consistent look and feel.