### PR TITLE
Add Export feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 
 ### Added
 
+- Add export capability to save diagrams as SVG or PNG files (#17).
 - Add zoom indicator showing current zoom percentage when zoomed or panned.
 - Add zoom in/out buttons to the view action bar for precise zoom control.
 

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -3,6 +3,7 @@ import {
 	WorkspaceLeaf,
 	MarkdownRenderer,
 	setIcon,
+	Notice,
 } from "obsidian";
 import { EditorView, lineNumbers, highlightActiveLine, drawSelection, keymap } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
@@ -137,6 +138,11 @@ export class MermaidView extends TextFileView {
 		// Add view action button for toggling mode
 		this.addAction("code", "Toggle source/preview", () => {
 			this.toggleMode();
+		});
+
+		// Add export button
+		this.addAction("download", "Export as SVG", () => {
+			this.exportAsSvg();
 		});
 
 		// Create zoom controls panel on the right side
@@ -479,5 +485,59 @@ export class MermaidView extends TextFileView {
 		this.scale = newScale;
 
 		this.applyTransform();
+	}
+
+	// ========== Export Methods ==========
+
+	private getSvgElement(): SVGSVGElement | null {
+		return this.zoomWrapper.querySelector(".mermaid svg");
+	}
+
+	private exportAsSvg(): void {
+		const svg = this.getSvgElement();
+		if (!svg) {
+			new Notice("No diagram to export. Render a diagram first.");
+			return;
+		}
+
+		// Clone the SVG to avoid modifying the displayed diagram
+		const clone = svg.cloneNode(true) as SVGSVGElement;
+
+		// Ensure the SVG has proper XML namespace
+		clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+
+		// Get dimensions from the original SVG
+		const bbox = svg.getBBox();
+		const width = svg.getAttribute("width") || bbox.width.toString();
+		const height = svg.getAttribute("height") || bbox.height.toString();
+
+		// Set viewBox if not present for proper scaling
+		if (!clone.getAttribute("viewBox")) {
+			clone.setAttribute("viewBox", `0 0 ${bbox.width} ${bbox.height}`);
+		}
+		clone.setAttribute("width", width);
+		clone.setAttribute("height", height);
+
+		// Serialize to string
+		const serializer = new XMLSerializer();
+		const svgString = serializer.serializeToString(clone);
+
+		// Create blob and download
+		const blob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
+		const filename = `${this.file?.basename ?? "diagram"}.svg`;
+
+		this.downloadBlob(blob, filename);
+		new Notice(`Exported ${filename}`);
+	}
+
+	private downloadBlob(blob: Blob, filename: string): void {
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement("a");
+		link.href = url;
+		link.download = filename;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
 	}
 }

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -4,12 +4,13 @@ import {
 	MarkdownRenderer,
 	setIcon,
 	Notice,
+	Menu,
 } from "obsidian";
 import { EditorView, lineNumbers, highlightActiveLine, drawSelection, keymap } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import type MermaidViewPlugin from "./main";
-import { exportAsSvg } from "./export";
+import { exportAsSvg, exportAsPng } from "./export";
 
 export const VIEW_TYPE_MERMAID = "mermaid-view";
 
@@ -142,8 +143,8 @@ export class MermaidView extends TextFileView {
 		});
 
 		// Add export button
-		this.addAction("download", "Export diagram", () => {
-			this.handleExport();
+		this.addAction("download", "Export diagram", (event) => {
+			this.showExportMenu(event);
 		});
 
 		// Create zoom controls panel on the right side
@@ -494,14 +495,32 @@ export class MermaidView extends TextFileView {
 		return this.zoomWrapper.querySelector(".mermaid svg");
 	}
 
-	private handleExport(): void {
+	private showExportMenu(event: MouseEvent): void {
 		const svg = this.getSvgElement();
 		if (!svg) {
 			new Notice("No diagram to export. Render a diagram first.");
 			return;
 		}
 
+		const menu = new Menu();
 		const filename = this.file?.basename ?? "diagram";
-		exportAsSvg(svg, { filename });
+
+		menu.addItem((item) => {
+			item.setTitle("Export as SVG")
+				.setIcon("file-code")
+				.onClick(() => {
+					exportAsSvg(svg, { filename });
+				});
+		});
+
+		menu.addItem((item) => {
+			item.setTitle("Export as PNG")
+				.setIcon("image")
+				.onClick(() => {
+					void exportAsPng(svg, { filename });
+				});
+		});
+
+		menu.showAtMouseEvent(event);
 	}
 }

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -517,10 +517,33 @@ export class MermaidView extends TextFileView {
 			item.setTitle("Export as PNG")
 				.setIcon("image")
 				.onClick(() => {
-					void exportAsPng(svg, { filename });
+					const { pngBackground } = this.plugin.settings;
+					const backgroundColor = this.resolveBackgroundColor(pngBackground);
+					void exportAsPng(svg, {
+						filename,
+						backgroundColor,
+					});
 				});
 		});
 
 		menu.showAtMouseEvent(event);
+	}
+
+	private resolveBackgroundColor(setting: string): string {
+		const style = getComputedStyle(document.body);
+
+		switch (setting) {
+			case "theme":
+				// Use the current theme's background
+				return style.getPropertyValue("--background-primary").trim() || "#ffffff";
+			case "light":
+				// Use the light theme background color
+				return style.getPropertyValue("--color-base-00").trim() || "#ffffff";
+			case "dark":
+				// Use the dark theme background color
+				return style.getPropertyValue("--color-base-100").trim() || "#1e1e1e";
+			default:
+				return setting;
+		}
 	}
 }

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -517,11 +517,12 @@ export class MermaidView extends TextFileView {
 			item.setTitle("Export as PNG")
 				.setIcon("image")
 				.onClick(() => {
-					const { pngBackground } = this.plugin.settings;
+					const { pngBackground, pngScale } = this.plugin.settings;
 					const backgroundColor = this.resolveBackgroundColor(pngBackground);
 					void exportAsPng(svg, {
 						filename,
 						backgroundColor,
+						scale: pngScale,
 					});
 				});
 		});

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -9,6 +9,7 @@ import { EditorView, lineNumbers, highlightActiveLine, drawSelection, keymap } f
 import { EditorState } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import type MermaidViewPlugin from "./main";
+import { exportAsSvg } from "./export";
 
 export const VIEW_TYPE_MERMAID = "mermaid-view";
 
@@ -141,8 +142,8 @@ export class MermaidView extends TextFileView {
 		});
 
 		// Add export button
-		this.addAction("download", "Export as SVG", () => {
-			this.exportAsSvg();
+		this.addAction("download", "Export diagram", () => {
+			this.handleExport();
 		});
 
 		// Create zoom controls panel on the right side
@@ -493,51 +494,14 @@ export class MermaidView extends TextFileView {
 		return this.zoomWrapper.querySelector(".mermaid svg");
 	}
 
-	private exportAsSvg(): void {
+	private handleExport(): void {
 		const svg = this.getSvgElement();
 		if (!svg) {
 			new Notice("No diagram to export. Render a diagram first.");
 			return;
 		}
 
-		// Clone the SVG to avoid modifying the displayed diagram
-		const clone = svg.cloneNode(true) as SVGSVGElement;
-
-		// Ensure the SVG has proper XML namespace
-		clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-
-		// Get dimensions from the original SVG
-		const bbox = svg.getBBox();
-		const width = svg.getAttribute("width") || bbox.width.toString();
-		const height = svg.getAttribute("height") || bbox.height.toString();
-
-		// Set viewBox if not present for proper scaling
-		if (!clone.getAttribute("viewBox")) {
-			clone.setAttribute("viewBox", `0 0 ${bbox.width} ${bbox.height}`);
-		}
-		clone.setAttribute("width", width);
-		clone.setAttribute("height", height);
-
-		// Serialize to string
-		const serializer = new XMLSerializer();
-		const svgString = serializer.serializeToString(clone);
-
-		// Create blob and download
-		const blob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
-		const filename = `${this.file?.basename ?? "diagram"}.svg`;
-
-		this.downloadBlob(blob, filename);
-		new Notice(`Exported ${filename}`);
-	}
-
-	private downloadBlob(blob: Blob, filename: string): void {
-		const url = URL.createObjectURL(blob);
-		const link = document.createElement("a");
-		link.href = url;
-		link.download = filename;
-		document.body.appendChild(link);
-		link.click();
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
+		const filename = this.file?.basename ?? "diagram";
+		exportAsSvg(svg, { filename });
 	}
 }

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,0 +1,132 @@
+import { App, Component, MarkdownRenderer, TFile } from "obsidian";
+
+/**
+ * Handles rendering of embedded mermaid files in notes.
+ */
+export class EmbedHandler {
+	private app: App;
+	private extensions: string[];
+	private observer: MutationObserver | null = null;
+	private components: Component[] = [];
+
+	constructor(app: App, extensions: string[]) {
+		this.app = app;
+		this.extensions = extensions;
+	}
+
+	/**
+	 * Starts observing the DOM for mermaid file embeds.
+	 */
+	start(addChild: (component: Component) => void): () => void {
+		this.observer = new MutationObserver((mutations) => {
+			for (const mutation of mutations) {
+				for (const node of Array.from(mutation.addedNodes)) {
+					if (node instanceof HTMLElement) {
+						this.processElement(node, addChild);
+						// Also check children
+						const embeds = node.querySelectorAll<HTMLElement>(".internal-embed.file-embed");
+						embeds.forEach((embed) => this.processElement(embed, addChild));
+					}
+				}
+			}
+		});
+
+		// Observe the entire document for embed elements
+		this.observer.observe(document.body, {
+			childList: true,
+			subtree: true,
+		});
+
+		// Process any existing embeds
+		document.querySelectorAll<HTMLElement>(".internal-embed.file-embed").forEach((embed) => {
+			this.processElement(embed, addChild);
+		});
+
+		// Return cleanup function
+		return () => this.stop();
+	}
+
+	/**
+	 * Stops observing and cleans up.
+	 */
+	stop(): void {
+		if (this.observer) {
+			this.observer.disconnect();
+			this.observer = null;
+		}
+	}
+
+	/**
+	 * Updates the list of supported extensions.
+	 */
+	setExtensions(extensions: string[]): void {
+		this.extensions = extensions;
+	}
+
+	/**
+	 * Processes an element to check if it's a mermaid embed.
+	 */
+	private processElement(el: HTMLElement, addChild: (component: Component) => void): void {
+		// Check if this is an internal-embed with file-embed class
+		if (!el.classList.contains("internal-embed") || !el.classList.contains("file-embed")) {
+			return;
+		}
+
+		// Skip if already processed
+		if (el.classList.contains("mermaid-embed")) return;
+
+		const src = el.getAttribute("src");
+		if (!src) return;
+
+		// Check if this is a mermaid file
+		const extension = src.split(".").pop()?.toLowerCase();
+		if (!extension || !this.extensions.includes(extension)) return;
+
+		// Render the mermaid embed
+		void this.renderEmbed(el, src, addChild);
+	}
+
+	/**
+	 * Renders a mermaid file embed.
+	 */
+	private async renderEmbed(
+		container: HTMLElement,
+		src: string,
+		addChild: (component: Component) => void
+	): Promise<void> {
+		// Find the file - try multiple resolution methods
+		let linkedFile: TFile | null = this.app.metadataCache.getFirstLinkpathDest(src, "");
+
+		if (!linkedFile) {
+			// Try finding by path directly
+			const abstractFile = this.app.vault.getAbstractFileByPath(src);
+			if (abstractFile instanceof TFile) {
+				linkedFile = abstractFile;
+			}
+		}
+
+		if (!linkedFile) return;
+
+		// Read the mermaid file content
+		const content = await this.app.vault.read(linkedFile);
+
+		// Mark as processed and update classes
+		container.empty();
+		container.addClass("mermaid-embed");
+		container.removeClass("file-embed", "mod-generic");
+
+		const mermaidMarkdown = "```mermaid\n" + content.trim() + "\n```";
+
+		const embedComponent = new Component();
+		addChild(embedComponent);
+		this.components.push(embedComponent);
+
+		await MarkdownRenderer.render(
+			this.app,
+			mermaidMarkdown,
+			container,
+			linkedFile.path,
+			embedComponent
+		);
+	}
+}

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -42,7 +42,6 @@ export class EmbedHandler {
 			this.processElement(embed, addChild);
 		});
 
-		// Return cleanup function
 		return () => this.stop();
 	}
 
@@ -82,7 +81,6 @@ export class EmbedHandler {
 		const extension = src.split(".").pop()?.toLowerCase();
 		if (!extension || !this.extensions.includes(extension)) return;
 
-		// Render the mermaid embed
 		void this.renderEmbed(el, src, addChild);
 	}
 
@@ -107,7 +105,6 @@ export class EmbedHandler {
 
 		if (!linkedFile) return;
 
-		// Read the mermaid file content
 		const content = await this.app.vault.read(linkedFile);
 
 		// Mark as processed and update classes

--- a/src/export.ts
+++ b/src/export.ts
@@ -122,8 +122,9 @@ export async function exportAsPng(svg: SVGSVGElement, options: ExportOptions): P
 
 	const svgString = serializeSvg(clone);
 
-	// Use data URL instead of blob URL to avoid "tainted canvas" security error
-	const base64 = btoa(unescape(encodeURIComponent(svgString)));
+	// Use data URL to avoid "tainted canvas" security error
+	const bytes = new TextEncoder().encode(svgString);
+	const base64 = btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
 	const dataUrl = `data:image/svg+xml;base64,${base64}`;
 
 	const img = await loadImage(dataUrl);

--- a/src/export.ts
+++ b/src/export.ts
@@ -69,3 +69,118 @@ export function exportAsSvg(svg: SVGSVGElement, options: ExportOptions): void {
 	downloadBlob(blob, filename);
 	new Notice(`Exported ${filename}`);
 }
+
+/**
+ * Gets the dimensions of an SVG element.
+ */
+function getSvgDimensions(svg: SVGSVGElement): { width: number; height: number } {
+	// Try to get dimensions from attributes first
+	const widthAttr = svg.getAttribute("width");
+	const heightAttr = svg.getAttribute("height");
+
+	if (widthAttr && heightAttr) {
+		const width = parseFloat(widthAttr);
+		const height = parseFloat(heightAttr);
+		if (!isNaN(width) && !isNaN(height)) {
+			return { width, height };
+		}
+	}
+
+	// Fall back to viewBox
+	const viewBox = svg.getAttribute("viewBox");
+	if (viewBox) {
+		const parts = viewBox.split(/\s+/);
+		const widthPart = parts[2];
+		const heightPart = parts[3];
+		if (parts.length === 4 && widthPart && heightPart) {
+			const width = parseFloat(widthPart);
+			const height = parseFloat(heightPart);
+			if (!isNaN(width) && !isNaN(height)) {
+				return { width, height };
+			}
+		}
+	}
+
+	// Last resort: getBBox
+	const bbox = svg.getBBox();
+	return { width: bbox.width, height: bbox.height };
+}
+
+/**
+ * Exports an SVG element as a PNG file.
+ */
+export async function exportAsPng(svg: SVGSVGElement, options: ExportOptions): Promise<void> {
+	const scale = options.scale ?? 2; // Default to 2x for retina displays
+	const backgroundColor = options.backgroundColor ?? "transparent";
+
+	const clone = prepareSvgForExport(svg);
+	const { width, height } = getSvgDimensions(svg);
+
+	// Set explicit dimensions on the clone for proper rendering
+	clone.setAttribute("width", width.toString());
+	clone.setAttribute("height", height.toString());
+
+	const svgString = serializeSvg(clone);
+
+	// Use data URL instead of blob URL to avoid "tainted canvas" security error
+	const base64 = btoa(unescape(encodeURIComponent(svgString)));
+	const dataUrl = `data:image/svg+xml;base64,${base64}`;
+
+	const img = await loadImage(dataUrl);
+
+	// Create canvas with scaled dimensions
+	const canvas = document.createElement("canvas");
+	canvas.width = width * scale;
+	canvas.height = height * scale;
+
+	const ctx = canvas.getContext("2d");
+	if (!ctx) {
+		throw new Error("Failed to get canvas context");
+	}
+
+	// Apply background color
+	if (backgroundColor !== "transparent") {
+		ctx.fillStyle = backgroundColor;
+		ctx.fillRect(0, 0, canvas.width, canvas.height);
+	}
+
+	// Scale and draw the image
+	ctx.scale(scale, scale);
+	ctx.drawImage(img, 0, 0, width, height);
+
+	// Convert to blob and download
+	const blob = await canvasToBlob(canvas, "image/png");
+	const filename = options.filename.endsWith(".png")
+		? options.filename
+		: `${options.filename}.png`;
+
+	downloadBlob(blob, filename);
+	new Notice(`Exported ${filename}`);
+}
+
+/**
+ * Loads an image from a URL.
+ */
+function loadImage(url: string): Promise<HTMLImageElement> {
+	return new Promise((resolve, reject) => {
+		const img = new Image();
+		img.onload = () => resolve(img);
+		img.onerror = () => reject(new Error("Failed to load image"));
+		img.src = url;
+	});
+}
+
+/**
+ * Converts a canvas to a blob.
+ */
+function canvasToBlob(canvas: HTMLCanvasElement, type: string): Promise<Blob> {
+	return new Promise((resolve, reject) => {
+		canvas.toBlob((blob) => {
+			if (blob) {
+				resolve(blob);
+			} else {
+				reject(new Error("Failed to create blob from canvas"));
+			}
+		}, type);
+	});
+}

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,0 +1,71 @@
+import { Notice } from "obsidian";
+
+export type ExportFormat = "svg" | "png";
+
+export interface ExportOptions {
+	filename: string;
+	scale?: number;
+	backgroundColor?: string;
+}
+
+/**
+ * Prepares an SVG element for export by cloning it and setting proper attributes.
+ */
+function prepareSvgForExport(svg: SVGSVGElement): SVGSVGElement {
+	const clone = svg.cloneNode(true) as SVGSVGElement;
+
+	// Ensure the SVG has proper XML namespace
+	clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+
+	// Get dimensions from the original SVG
+	const bbox = svg.getBBox();
+	const width = svg.getAttribute("width") || bbox.width.toString();
+	const height = svg.getAttribute("height") || bbox.height.toString();
+
+	// Set viewBox if not present for proper scaling
+	if (!clone.getAttribute("viewBox")) {
+		clone.setAttribute("viewBox", `0 0 ${bbox.width} ${bbox.height}`);
+	}
+	clone.setAttribute("width", width);
+	clone.setAttribute("height", height);
+
+	return clone;
+}
+
+/**
+ * Serializes an SVG element to a string.
+ */
+function serializeSvg(svg: SVGSVGElement): string {
+	const serializer = new XMLSerializer();
+	return serializer.serializeToString(svg);
+}
+
+/**
+ * Downloads a blob as a file.
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement("a");
+	link.href = url;
+	link.download = filename;
+	document.body.appendChild(link);
+	link.click();
+	document.body.removeChild(link);
+	URL.revokeObjectURL(url);
+}
+
+/**
+ * Exports an SVG element as an SVG file.
+ */
+export function exportAsSvg(svg: SVGSVGElement, options: ExportOptions): void {
+	const clone = prepareSvgForExport(svg);
+	const svgString = serializeSvg(clone);
+
+	const blob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
+	const filename = options.filename.endsWith(".svg")
+		? options.filename
+		: `${options.filename}.svg`;
+
+	downloadBlob(blob, filename);
+	new Notice(`Exported ${filename}`);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,15 @@
-import { Component, MarkdownRenderer, Menu, Plugin, TAbstractFile, TFile, TFolder } from "obsidian";
+import { Menu, Plugin, TAbstractFile, TFolder } from "obsidian";
 import { MermaidView, VIEW_TYPE_MERMAID } from "./MermaidView";
 import {
 	MermaidViewSettings,
 	DEFAULT_SETTINGS,
 	MermaidViewSettingTab,
 } from "./settings";
+import { EmbedHandler } from "./embed";
 
 export default class MermaidViewPlugin extends Plugin {
 	settings: MermaidViewSettings;
+	private embedHandler: EmbedHandler;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
@@ -65,92 +67,9 @@ export default class MermaidViewPlugin extends Plugin {
 		);
 
 		// Watch for mermaid file embeds being added to the DOM
-		this.setupEmbedObserver();
-	}
-
-	private setupEmbedObserver(): void {
-		const observer = new MutationObserver((mutations) => {
-			for (const mutation of mutations) {
-				for (const node of Array.from(mutation.addedNodes)) {
-					if (node instanceof HTMLElement) {
-						this.processEmbedElement(node);
-						// Also check children
-						const embeds = node.querySelectorAll<HTMLElement>(".internal-embed.file-embed");
-						embeds.forEach((embed) => this.processEmbedElement(embed));
-					}
-				}
-			}
-		});
-
-		// Observe the entire document for embed elements
-		observer.observe(document.body, {
-			childList: true,
-			subtree: true,
-		});
-
-		// Store observer for cleanup
-		this.register(() => observer.disconnect());
-
-		// Process any existing embeds
-		document.querySelectorAll<HTMLElement>(".internal-embed.file-embed").forEach((embed) => {
-			this.processEmbedElement(embed);
-		});
-	}
-
-	private processEmbedElement(el: HTMLElement): void {
-		// Check if this is an internal-embed with file-embed class
-		if (!el.classList.contains("internal-embed") || !el.classList.contains("file-embed")) {
-			return;
-		}
-
-		// Skip if already processed
-		if (el.classList.contains("mermaid-embed")) return;
-
-		const src = el.getAttribute("src");
-		if (!src) return;
-
-		// Check if this is a mermaid file
-		const extension = src.split(".").pop()?.toLowerCase();
-		if (!extension || !this.settings.extensions.includes(extension)) return;
-
-		// Render the mermaid embed
-		void this.renderMermaidEmbed(el, src);
-	}
-
-	private async renderMermaidEmbed(container: HTMLElement, src: string): Promise<void> {
-		// Find the file - try multiple resolution methods
-		let linkedFile: TFile | null = this.app.metadataCache.getFirstLinkpathDest(src, "");
-
-		if (!linkedFile) {
-			// Try finding by path directly
-			const abstractFile = this.app.vault.getAbstractFileByPath(src);
-			if (abstractFile instanceof TFile) {
-				linkedFile = abstractFile;
-			}
-		}
-
-		if (!linkedFile) return;
-
-		// Read the mermaid file content
-		const content = await this.app.vault.read(linkedFile);
-
-		// Mark as processed and update classes
-		container.empty();
-		container.addClass("mermaid-embed");
-		container.removeClass("file-embed", "mod-generic");
-
-		const mermaidMarkdown = "```mermaid\n" + content.trim() + "\n```";
-
-		const embedComponent = new Component();
-		this.addChild(embedComponent);
-
-		await MarkdownRenderer.render(
-			this.app,
-			mermaidMarkdown,
-			container,
-			linkedFile.path,
-			embedComponent
-		);
+		this.embedHandler = new EmbedHandler(this.app, this.settings.extensions);
+		const stopEmbedObserver = this.embedHandler.start((component) => this.addChild(component));
+		this.register(stopEmbedObserver);
 	}
 
 	async createMermaidFile(folder: TFolder): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,16 +3,19 @@ import type MermaidViewPlugin from "./main";
 
 export type SplitLayout = "editor-left" | "editor-right";
 export type PngBackground = "transparent" | "light" | "dark" | "theme";
+export type PngScale = 1 | 2 | 3 | 4;
 
 export interface MermaidViewSettings {
 	extensions: string[];
 	splitLayout: SplitLayout;
 	pngBackground: PngBackground;
+	pngScale: PngScale;
 }
 
 export const DEFAULT_SETTINGS: MermaidViewSettings = {
 	extensions: ["mermaid", "mmd"],
 	splitLayout: "editor-left",
+	pngScale: 2,
 	pngBackground: "transparent",
 };
 
@@ -78,6 +81,22 @@ export class MermaidViewSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.pngBackground)
 					.onChange(async (value: PngBackground) => {
 						this.plugin.settings.pngBackground = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName("PNG scale")
+			.setDesc("Scale factor for PNG exports. Higher values produce larger, sharper images.")
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOption("1", "1x (standard)")
+					.addOption("2", "2x (retina)")
+					.addOption("3", "3x (high resolution)")
+					.addOption("4", "4x (very high resolution)")
+					.setValue(this.plugin.settings.pngScale.toString())
+					.onChange(async (value) => {
+						this.plugin.settings.pngScale = parseInt(value) as PngScale;
 						await this.plugin.saveSettings();
 					})
 			);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -67,7 +67,7 @@ export class MermaidViewSettingTab extends PluginSettingTab {
 					})
 			);
 
-		containerEl.createEl("h3", { text: "Export" });
+		new Setting(containerEl).setName("Export").setHeading();
 
 		new Setting(containerEl)
 			.setName("PNG background")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,7 +39,7 @@ export class MermaidViewSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("File extensions")
 			.setDesc(
-				"Comma-separated list of file extensions to treat as Mermaid files (without the dot). Changes require restarting Obsidian."
+				"Comma-separated list of file extensions (without the dot) to treat as Mermaid files. (Requires restarting Obsidian to take effect)"
 			)
 			.addText((text) =>
 				text
@@ -49,11 +49,6 @@ export class MermaidViewSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
-
-		containerEl.createEl("p", {
-			text: "Restart Obsidian after changing extensions for the changes to take effect.",
-			cls: "setting-item-description",
-		});
 
 		new Setting(containerEl)
 			.setName("Split view layout")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,15 +2,18 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import type MermaidViewPlugin from "./main";
 
 export type SplitLayout = "editor-left" | "editor-right";
+export type PngBackground = "transparent" | "light" | "dark" | "theme";
 
 export interface MermaidViewSettings {
 	extensions: string[];
 	splitLayout: SplitLayout;
+	pngBackground: PngBackground;
 }
 
 export const DEFAULT_SETTINGS: MermaidViewSettings = {
 	extensions: ["mermaid", "mmd"],
 	splitLayout: "editor-left",
+	pngBackground: "transparent",
 };
 
 export function parseExtensions(value: string): string[] {
@@ -62,6 +65,24 @@ export class MermaidViewSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.splitLayout)
 					.onChange(async (value: SplitLayout) => {
 						this.plugin.settings.splitLayout = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		containerEl.createEl("h3", { text: "Export" });
+
+		new Setting(containerEl)
+			.setName("PNG background")
+			.setDesc("Background color for PNG exports.")
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOption("transparent", "Transparent")
+					.addOption("light", "Light")
+					.addOption("dark", "Dark")
+					.addOption("theme", "Match current theme")
+					.setValue(this.plugin.settings.pngBackground)
+					.onChange(async (value: PngBackground) => {
+						this.plugin.settings.pngBackground = value;
 						await this.plugin.saveSettings();
 					})
 			);


### PR DESCRIPTION
Add export capability. For now, add support just to SVG and PNG, as they are the easiest one without adding external additional dependencies.

I am still constrained by not being able to access the Mermaid lib directly in Obsidian, but having to pass through obsidian rendering system. For now, not worth bringing in another deps to Mermaid lib.

Closes https://github.com/weppos/obsidian-mermaid-view/issues/12
