### PR TITLE
Add Export/Pan/Zoom to embedded diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 
 ## Unreleased
 
+### Added
+
+- Add export (SVG/PNG) and pan/zoom support to embedded Mermaid diagrams, both in markdown `` ```mermaid `` code blocks and `![[file]]` embeds (#18).
+
 ## 0.4.0 - 2026-02-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Mermaid View is a type of [view](https://help.obsidian.md/bases/views) you can u
   ```
 - **Menu integration** - Right-click in the file explorer to create a new Mermaid file, or use the command palette.
 
+### Feature Comparison
+
+Mermaid diagrams can be rendered in three ways within Obsidian. This plugin enhances all of them:
+
+| Rendering method | Export PNG/SVG | Pan/Zoom |
+|------------------|:--------------:|:--------:|
+| ` ```mermaid` ` code block | ✅ | ✅ |
+| `![[file.mermaid]]` embed | ✅ | ✅ |
+| Standalone `.mermaid` file | ✅ | ✅ |
+
 ### Preview Mode
 
 View your diagrams full-screen with pan and zoom support.

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -11,6 +11,7 @@ import { EditorState } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import type MermaidViewPlugin from "./main";
 import { exportAsSvg, exportAsPng } from "./export";
+import { PanZoomHandler } from "./panZoom";
 
 export const VIEW_TYPE_MERMAID = "mermaid-view";
 
@@ -23,22 +24,9 @@ export class MermaidView extends TextFileView {
 	private sourceEl: HTMLElement;
 	private editorView: EditorView;
 
-	// Pan/zoom state
+	// Pan/zoom handler
 	private zoomWrapper: HTMLElement;
-	private scale = 1;
-	private translateX = 0;
-	private translateY = 0;
-	private isPanning = false;
-	private startX = 0;
-	private startY = 0;
-	private readonly MIN_SCALE = 0.1;
-	private readonly MAX_SCALE = 5;
-
-	// Touch gesture state
-	private initialPinchDistance = 0;
-	private initialPinchScale = 1;
-
-	// Zoom indicator
+	private panZoomHandler: PanZoomHandler;
 	private zoomIndicator: HTMLElement;
 
 	// Debounce timer for live preview
@@ -80,8 +68,11 @@ export class MermaidView extends TextFileView {
 			text: "100%",
 		});
 
-		// Set up pan/zoom event handlers
-		this.setupPanZoom();
+		// Set up pan/zoom handler with full gesture support
+		this.panZoomHandler = new PanZoomHandler(this.previewEl, this.zoomWrapper);
+		this.panZoomHandler.setOnScaleChange((scale, translateX, translateY) => {
+			this.updateZoomIndicator(scale, translateX, translateY);
+		});
 
 		// Create source editor container
 		this.sourceEl = container.createDiv({ cls: "mermaid-view-source" });
@@ -155,6 +146,7 @@ export class MermaidView extends TextFileView {
 	}
 
 	async onClose(): Promise<void> {
+		this.panZoomHandler.destroy();
 		this.editorView.destroy();
 		this.contentEl.empty();
 		await super.onClose();
@@ -253,7 +245,7 @@ export class MermaidView extends TextFileView {
 	private async renderPreview(preserveZoom = false): Promise<void> {
 		this.zoomWrapper.empty();
 		if (!preserveZoom) {
-			this.resetZoom();
+			this.panZoomHandler.resetZoom();
 		}
 
 		const content = (this.data ?? "").trim();
@@ -289,138 +281,12 @@ export class MermaidView extends TextFileView {
 		}
 	}
 
-	private setupPanZoom(): void {
-		// Wheel event for zooming
-		this.registerDomEvent(this.previewEl, "wheel", (e: WheelEvent) => {
-			e.preventDefault();
-
-			const rect = this.previewEl.getBoundingClientRect();
-			const mouseX = e.clientX - rect.left;
-			const mouseY = e.clientY - rect.top;
-
-			// Calculate zoom
-			const zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
-			const newScale = Math.min(
-				this.MAX_SCALE,
-				Math.max(this.MIN_SCALE, this.scale * zoomFactor)
-			);
-
-			// Zoom toward mouse position
-			const scaleChange = newScale / this.scale;
-			this.translateX = mouseX - scaleChange * (mouseX - this.translateX);
-			this.translateY = mouseY - scaleChange * (mouseY - this.translateY);
-			this.scale = newScale;
-
-			this.applyTransform();
-		}, { passive: false });
-
-		// Mouse events for panning
-		this.registerDomEvent(this.previewEl, "mousedown", (e: MouseEvent) => {
-			if (e.button !== 0) return; // Only left click
-			this.isPanning = true;
-			this.startX = e.clientX - this.translateX;
-			this.startY = e.clientY - this.translateY;
-			this.previewEl.addClass("mermaid-view-panning");
-		});
-
-		this.registerDomEvent(this.previewEl, "mousemove", (e: MouseEvent) => {
-			if (!this.isPanning) return;
-			this.translateX = e.clientX - this.startX;
-			this.translateY = e.clientY - this.startY;
-			this.applyTransform();
-		});
-
-		this.registerDomEvent(this.previewEl, "mouseup", () => {
-			this.isPanning = false;
-			this.previewEl.removeClass("mermaid-view-panning");
-		});
-
-		this.registerDomEvent(this.previewEl, "mouseleave", () => {
-			this.isPanning = false;
-			this.previewEl.removeClass("mermaid-view-panning");
-		});
-
-		// Double-click to reset
-		this.registerDomEvent(this.previewEl, "dblclick", () => {
-			this.resetZoom();
-		});
-
-		// Touch events for mobile pan/zoom
-		this.registerDomEvent(this.previewEl, "touchstart", (e: TouchEvent) => {
-			const touch1 = e.touches[0];
-			const touch2 = e.touches[1];
-
-			if (e.touches.length === 2 && touch1 && touch2) {
-				// Pinch zoom start
-				this.initialPinchDistance = Math.hypot(
-					touch2.clientX - touch1.clientX,
-					touch2.clientY - touch1.clientY
-				);
-				this.initialPinchScale = this.scale;
-			} else if (e.touches.length === 1 && touch1) {
-				// Single touch pan
-				this.isPanning = true;
-				this.startX = touch1.clientX - this.translateX;
-				this.startY = touch1.clientY - this.translateY;
-				this.previewEl.addClass("mermaid-view-panning");
-			}
-		});
-
-		this.registerDomEvent(this.previewEl, "touchmove", (e: TouchEvent) => {
-			e.preventDefault();
-
-			const touch1 = e.touches[0];
-			const touch2 = e.touches[1];
-
-			if (e.touches.length === 2 && touch1 && touch2) {
-				// Pinch zoom
-				const currentDistance = Math.hypot(
-					touch2.clientX - touch1.clientX,
-					touch2.clientY - touch1.clientY
-				);
-
-				const scaleRatio = currentDistance / this.initialPinchDistance;
-				const newScale = Math.min(
-					this.MAX_SCALE,
-					Math.max(this.MIN_SCALE, this.initialPinchScale * scaleRatio)
-				);
-
-				// Zoom toward pinch center
-				const rect = this.previewEl.getBoundingClientRect();
-				const centerX = (touch1.clientX + touch2.clientX) / 2 - rect.left;
-				const centerY = (touch1.clientY + touch2.clientY) / 2 - rect.top;
-
-				const scaleChange = newScale / this.scale;
-				this.translateX = centerX - scaleChange * (centerX - this.translateX);
-				this.translateY = centerY - scaleChange * (centerY - this.translateY);
-				this.scale = newScale;
-
-				this.applyTransform();
-			} else if (e.touches.length === 1 && touch1 && this.isPanning) {
-				// Single touch pan
-				this.translateX = touch1.clientX - this.startX;
-				this.translateY = touch1.clientY - this.startY;
-				this.applyTransform();
-			}
-		}, { passive: false });
-
-		this.registerDomEvent(this.previewEl, "touchend", () => {
-			this.isPanning = false;
-			this.previewEl.removeClass("mermaid-view-panning");
-		});
-	}
-
-	private applyTransform(): void {
-		this.zoomWrapper.style.transform = `translate(${this.translateX}px, ${this.translateY}px) scale(${this.scale})`;
-		this.updateZoomIndicator();
-	}
-
-	private updateZoomIndicator(): void {
-		const percentage = Math.round(this.scale * 100);
+	private updateZoomIndicator(scale: number, translateX: number, translateY: number): void {
+		const percentage = Math.round(scale * 100);
 		this.zoomIndicator.textContent = `${percentage}%`;
 
 		// Show/hide based on whether zoom is at default
-		if (this.scale === 1 && this.translateX === 0 && this.translateY === 0) {
+		if (scale === 1 && translateX === 0 && translateY === 0) {
 			this.zoomIndicator.removeClass("mermaid-zoom-indicator-active");
 		} else {
 			this.zoomIndicator.addClass("mermaid-zoom-indicator-active");
@@ -438,55 +304,21 @@ export class MermaidView extends TextFileView {
 			attr: { "aria-label": "Zoom in" },
 		});
 		setIcon(zoomInBtn, "plus");
-		zoomInBtn.addEventListener("click", () => this.zoomIn());
+		zoomInBtn.addEventListener("click", () => this.panZoomHandler.zoomIn());
 
 		const resetBtn = zoomGroup.createDiv({
 			cls: "mermaid-zoom-control-item",
 			attr: { "aria-label": "Reset zoom" },
 		});
 		setIcon(resetBtn, "rotate-cw");
-		resetBtn.addEventListener("click", () => this.resetZoom());
+		resetBtn.addEventListener("click", () => this.panZoomHandler.resetZoom());
 
 		const zoomOutBtn = zoomGroup.createDiv({
 			cls: "mermaid-zoom-control-item",
 			attr: { "aria-label": "Zoom out" },
 		});
 		setIcon(zoomOutBtn, "minus");
-		zoomOutBtn.addEventListener("click", () => this.zoomOut());
-	}
-
-	private resetZoom(): void {
-		this.scale = 1;
-		this.translateX = 0;
-		this.translateY = 0;
-		this.applyTransform();
-	}
-
-	private zoomIn(): void {
-		this.zoomToCenter(1.2);
-	}
-
-	private zoomOut(): void {
-		this.zoomToCenter(0.8);
-	}
-
-	private zoomToCenter(factor: number): void {
-		const newScale = Math.min(
-			this.MAX_SCALE,
-			Math.max(this.MIN_SCALE, this.scale * factor)
-		);
-
-		// Zoom toward center of preview area
-		const rect = this.previewEl.getBoundingClientRect();
-		const centerX = rect.width / 2;
-		const centerY = rect.height / 2;
-
-		const scaleChange = newScale / this.scale;
-		this.translateX = centerX - scaleChange * (centerX - this.translateX);
-		this.translateY = centerY - scaleChange * (centerY - this.translateY);
-		this.scale = newScale;
-
-		this.applyTransform();
+		zoomOutBtn.addEventListener("click", () => this.panZoomHandler.zoomOut());
 	}
 
 	// ========== Export Methods ==========

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
 	MermaidViewSettingTab,
 } from "./settings";
 import { EmbedHandler } from "./embed";
+import { registerMermaidExportPostProcessor, createLivePreviewExportObserver } from "./markdownExport";
 
 export default class MermaidViewPlugin extends Plugin {
 	settings: MermaidViewSettings;
@@ -70,6 +71,17 @@ export default class MermaidViewPlugin extends Plugin {
 		this.embedHandler = new EmbedHandler(this.app, this.settings.extensions);
 		const stopEmbedObserver = this.embedHandler.start((component) => this.addChild(component));
 		this.register(stopEmbedObserver);
+
+		// Register post-processor for export buttons on mermaid diagrams in markdown (Reading View)
+		registerMermaidExportPostProcessor(
+			this.app,
+			this.settings,
+			(processor) => this.registerMarkdownPostProcessor(processor)
+		);
+
+		// Register observer for export buttons on mermaid diagrams in Live Preview
+		const stopLivePreviewObserver = createLivePreviewExportObserver(this.app, this.settings);
+		this.register(stopLivePreviewObserver);
 	}
 
 	async createMermaidFile(folder: TFolder): Promise<void> {

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -1,0 +1,272 @@
+import { App, MarkdownPostProcessorContext, Menu, setIcon } from "obsidian";
+import { exportAsSvg, exportAsPng } from "./export";
+import type { MermaidViewSettings, PngBackground } from "./settings";
+
+/**
+ * Resolves the background color setting to an actual color value.
+ */
+function resolveBackgroundColor(setting: PngBackground): string {
+	const style = getComputedStyle(document.body);
+
+	switch (setting) {
+		case "theme":
+			return style.getPropertyValue("--background-primary").trim() || "#ffffff";
+		case "light":
+			return style.getPropertyValue("--color-base-00").trim() || "#ffffff";
+		case "dark":
+			return style.getPropertyValue("--color-base-100").trim() || "#1e1e1e";
+		default:
+			return setting;
+	}
+}
+
+/**
+ * Generates a filename for the export based on the source file path or a default.
+ */
+function generateFilename(sourcePath: string, index: number): string {
+	if (!sourcePath) {
+		return index > 0 ? `diagram-${index + 1}` : "diagram";
+	}
+
+	// Extract basename without extension
+	const parts = sourcePath.split("/");
+	const filename = parts[parts.length - 1] || "diagram";
+	const basename = filename.replace(/\.[^.]+$/, "");
+
+	// Add index suffix if there might be multiple diagrams
+	return index > 0 ? `${basename}-${index + 1}` : basename;
+}
+
+/**
+ * Creates an export button element for a mermaid diagram.
+ */
+function createExportButton(
+	svg: SVGSVGElement,
+	filename: string,
+	settings: MermaidViewSettings
+): HTMLElement {
+	const button = document.createElement("button");
+	button.className = "mermaid-export-button";
+	button.setAttribute("aria-label", "Export diagram");
+
+	// Use Obsidian's setIcon for consistent icon rendering
+	setIcon(button, "download");
+
+	button.addEventListener("click", (event) => {
+		event.preventDefault();
+		event.stopPropagation();
+		showExportMenu(event, svg, filename, settings);
+	});
+
+	return button;
+}
+
+/**
+ * Shows the export menu with SVG and PNG options.
+ */
+function showExportMenu(
+	event: MouseEvent,
+	svg: SVGSVGElement,
+	filename: string,
+	settings: MermaidViewSettings
+): void {
+	const menu = new Menu();
+
+	menu.addItem((item) => {
+		item.setTitle("Export as SVG")
+			.setIcon("file-code")
+			.onClick(() => {
+				void exportAsSvg(svg, { filename });
+			});
+	});
+
+	menu.addItem((item) => {
+		item.setTitle("Export as PNG")
+			.setIcon("image")
+			.onClick(() => {
+				const backgroundColor = resolveBackgroundColor(settings.pngBackground);
+				void exportAsPng(svg, {
+					filename,
+					backgroundColor,
+					scale: settings.pngScale,
+				});
+			});
+	});
+
+	menu.showAtMouseEvent(event);
+}
+
+/**
+ * Adds export functionality to a mermaid container element.
+ */
+function addExportToMermaid(
+	mermaidEl: Element,
+	sourcePath: string,
+	index: number,
+	settings: MermaidViewSettings
+): void {
+	// Check if we've already processed this element
+	if (mermaidEl.classList.contains("mermaid-export-processed")) {
+		return;
+	}
+
+	const svg = mermaidEl.querySelector<SVGSVGElement>("svg");
+	if (!svg) {
+		return;
+	}
+
+	// Mark as processed
+	mermaidEl.classList.add("mermaid-export-processed");
+
+	// Create wrapper for positioning the export button
+	const wrapper = document.createElement("div");
+	wrapper.className = "mermaid-export-wrapper";
+
+	// Move the mermaid content into the wrapper
+	const parent = mermaidEl.parentElement;
+	if (!parent) return;
+
+	parent.insertBefore(wrapper, mermaidEl);
+	wrapper.appendChild(mermaidEl);
+
+	// Add export button
+	const filename = generateFilename(sourcePath, index);
+	const button = createExportButton(svg, filename, settings);
+	wrapper.appendChild(button);
+}
+
+/**
+ * Waits for an SVG element to appear in a mermaid container.
+ * Mermaid diagrams render asynchronously, so we need to observe for changes.
+ */
+function waitForSvg(mermaidEl: Element, timeout = 5000): Promise<SVGSVGElement | null> {
+	return new Promise((resolve) => {
+		// Check if SVG already exists
+		const existingSvg = mermaidEl.querySelector<SVGSVGElement>("svg");
+		if (existingSvg) {
+			resolve(existingSvg);
+			return;
+		}
+
+		// Set up observer to wait for SVG
+		const observer = new MutationObserver((mutations, obs) => {
+			const svg = mermaidEl.querySelector<SVGSVGElement>("svg");
+			if (svg) {
+				obs.disconnect();
+				resolve(svg);
+			}
+		});
+
+		observer.observe(mermaidEl, {
+			childList: true,
+			subtree: true,
+		});
+
+		// Timeout fallback
+		setTimeout(() => {
+			observer.disconnect();
+			resolve(mermaidEl.querySelector<SVGSVGElement>("svg"));
+		}, timeout);
+	});
+}
+
+/**
+ * Processes a mermaid element to add export functionality.
+ */
+function processMermaidElement(
+	mermaidEl: Element,
+	sourcePath: string,
+	index: number,
+	settings: MermaidViewSettings
+): void {
+	void waitForSvg(mermaidEl).then((svg) => {
+		if (svg) {
+			addExportToMermaid(mermaidEl, sourcePath, index, settings);
+		}
+	});
+}
+
+/**
+ * Registers the markdown post-processor for mermaid export functionality.
+ * This handles Reading View.
+ */
+export function registerMermaidExportPostProcessor(
+	app: App,
+	settings: MermaidViewSettings,
+	register: (processor: (el: HTMLElement, ctx: MarkdownPostProcessorContext) => void) => void
+): void {
+	register((el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+		const mermaidElements = el.querySelectorAll(".mermaid");
+
+		mermaidElements.forEach((mermaidEl, index) => {
+			processMermaidElement(mermaidEl, ctx.sourcePath, index, settings);
+		});
+	});
+}
+
+/**
+ * Creates a MutationObserver to handle mermaid diagrams in Live Preview mode.
+ * Returns a cleanup function to stop observing.
+ */
+export function createLivePreviewExportObserver(
+	app: App,
+	settings: MermaidViewSettings
+): () => void {
+	let diagramCounter = 0;
+
+	const processElement = (el: Element): void => {
+		// Look for mermaid containers in Live Preview
+		// Structure: .cm-preview-code-block.cm-embed-block.cm-lang-mermaid > .mermaid > svg
+		if (el.matches?.(".cm-preview-code-block.cm-lang-mermaid")) {
+			const mermaidEl = el.querySelector(".mermaid");
+			if (mermaidEl && !mermaidEl.classList.contains("mermaid-export-processed")) {
+				// Try to get source path from the active file
+				const sourcePath = app.workspace.getActiveFile()?.path ?? "";
+				processMermaidElement(mermaidEl, sourcePath, diagramCounter++, settings);
+			}
+		}
+
+		// Also check for .mermaid elements directly (Reading View structure)
+		if (el.matches?.(".mermaid") && !el.classList.contains("mermaid-export-processed")) {
+			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
+			processMermaidElement(el, sourcePath, diagramCounter++, settings);
+		}
+	};
+
+	const observer = new MutationObserver((mutations) => {
+		for (const mutation of mutations) {
+			for (const node of Array.from(mutation.addedNodes)) {
+				if (node instanceof HTMLElement) {
+					// Check the node itself
+					processElement(node);
+
+					// Check children for mermaid containers
+					const mermaidContainers = node.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid");
+					mermaidContainers.forEach(processElement);
+
+					// Also check for .mermaid elements directly
+					const mermaidElements = node.querySelectorAll(".mermaid");
+					mermaidElements.forEach(processElement);
+				}
+			}
+		}
+	});
+
+	// Observe the entire document
+	observer.observe(document.body, {
+		childList: true,
+		subtree: true,
+	});
+
+	// Process any existing mermaid diagrams
+	document.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid").forEach(processElement);
+	document.querySelectorAll(".mermaid:not(.mermaid-export-processed)").forEach((el) => {
+		const sourcePath = app.workspace.getActiveFile()?.path ?? "";
+		processMermaidElement(el, sourcePath, diagramCounter++, settings);
+	});
+
+	// Return cleanup function
+	return () => {
+		observer.disconnect();
+	};
+}

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownPostProcessorContext, Menu, setIcon } from "obsidian";
+import { App, MarkdownPostProcessorContext, Menu, Platform, setIcon } from "obsidian";
 import { exportAsSvg, exportAsPng } from "./export";
 import { PanZoomHandler } from "./panZoom";
 import type { MermaidViewSettings, PngBackground } from "./settings";
@@ -174,6 +174,9 @@ function addToolbarToMermaid(
 	// Create main wrapper for the diagram
 	const wrapper = document.createElement("div");
 	wrapper.className = "mermaid-diagram-wrapper";
+	if (Platform.isMobile) {
+		wrapper.classList.add("is-mobile");
+	}
 
 	// Create zoom container (provides overflow: hidden)
 	const zoomContainer = document.createElement("div");

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -1,5 +1,6 @@
 import { App, MarkdownPostProcessorContext, Menu, setIcon } from "obsidian";
 import { exportAsSvg, exportAsPng } from "./export";
+import { PanZoomHandler } from "./panZoom";
 import type { MermaidViewSettings, PngBackground } from "./settings";
 
 /**
@@ -38,27 +39,66 @@ function generateFilename(sourcePath: string, index: number): string {
 }
 
 /**
- * Creates an export button element for a mermaid diagram.
+ * Creates the toolbar with zoom controls and export button.
  */
-function createExportButton(
+function createToolbar(
 	svg: SVGSVGElement,
 	filename: string,
-	settings: MermaidViewSettings
+	settings: MermaidViewSettings,
+	panZoomHandler: PanZoomHandler
 ): HTMLElement {
-	const button = document.createElement("button");
-	button.className = "mermaid-export-button";
-	button.setAttribute("aria-label", "Export diagram");
+	const toolbar = document.createElement("div");
+	toolbar.className = "mermaid-toolbar";
 
-	// Use Obsidian's setIcon for consistent icon rendering
-	setIcon(button, "download");
+	// Zoom in button
+	const zoomInBtn = document.createElement("button");
+	zoomInBtn.className = "mermaid-toolbar-button";
+	zoomInBtn.setAttribute("aria-label", "Zoom in");
+	setIcon(zoomInBtn, "plus");
+	zoomInBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		panZoomHandler.zoomIn();
+	});
+	toolbar.appendChild(zoomInBtn);
 
-	button.addEventListener("click", (event) => {
+	// Reset zoom button
+	const resetBtn = document.createElement("button");
+	resetBtn.className = "mermaid-toolbar-button";
+	resetBtn.setAttribute("aria-label", "Reset zoom");
+	setIcon(resetBtn, "rotate-cw");
+	resetBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		panZoomHandler.resetZoom();
+	});
+	toolbar.appendChild(resetBtn);
+
+	// Zoom out button
+	const zoomOutBtn = document.createElement("button");
+	zoomOutBtn.className = "mermaid-toolbar-button";
+	zoomOutBtn.setAttribute("aria-label", "Zoom out");
+	setIcon(zoomOutBtn, "minus");
+	zoomOutBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		panZoomHandler.zoomOut();
+	});
+	toolbar.appendChild(zoomOutBtn);
+
+	// Export button
+	const exportBtn = document.createElement("button");
+	exportBtn.className = "mermaid-toolbar-button";
+	exportBtn.setAttribute("aria-label", "Export diagram");
+	setIcon(exportBtn, "download");
+	exportBtn.addEventListener("click", (event) => {
 		event.preventDefault();
 		event.stopPropagation();
 		showExportMenu(event, svg, filename, settings);
 	});
+	toolbar.appendChild(exportBtn);
 
-	return button;
+	return toolbar;
 }
 
 /**
@@ -98,27 +138,27 @@ function showExportMenu(
 
 /**
  * Checks if an element is inside the standalone MermaidView.
- * We don't want to add export buttons there since it has its own export menu.
+ * We don't want to add toolbar/zoom there since it has its own controls.
  */
 function isInsideMermaidView(el: Element): boolean {
 	return el.closest(".mermaid-view-container") !== null;
 }
 
 /**
- * Adds export functionality to a mermaid container element.
+ * Adds pan/zoom and export functionality to a mermaid container element.
  */
-function addExportToMermaid(
+function addToolbarToMermaid(
 	mermaidEl: Element,
 	sourcePath: string,
 	index: number,
 	settings: MermaidViewSettings
 ): void {
 	// Check if we've already processed this element
-	if (mermaidEl.classList.contains("mermaid-export-processed")) {
+	if (mermaidEl.classList.contains("mermaid-toolbar-processed")) {
 		return;
 	}
 
-	// Skip elements inside the standalone MermaidView (it has its own export)
+	// Skip elements inside the standalone MermaidView (it has its own controls)
 	if (isInsideMermaidView(mermaidEl)) {
 		return;
 	}
@@ -129,23 +169,45 @@ function addExportToMermaid(
 	}
 
 	// Mark as processed
-	mermaidEl.classList.add("mermaid-export-processed");
+	mermaidEl.classList.add("mermaid-toolbar-processed");
 
-	// Create wrapper for positioning the export button
+	// Create main wrapper for the diagram
 	const wrapper = document.createElement("div");
-	wrapper.className = "mermaid-export-wrapper";
+	wrapper.className = "mermaid-diagram-wrapper";
 
-	// Move the mermaid content into the wrapper
+	// Create zoom container (provides overflow: hidden)
+	const zoomContainer = document.createElement("div");
+	zoomContainer.className = "mermaid-zoom-container";
+
+	// Create zoom wrapper (receives transforms)
+	const zoomWrapper = document.createElement("div");
+	zoomWrapper.className = "mermaid-embedded-zoom-wrapper";
+
+	// Move the mermaid content into the zoom wrapper
 	const parent = mermaidEl.parentElement;
 	if (!parent) return;
 
 	parent.insertBefore(wrapper, mermaidEl);
-	wrapper.appendChild(mermaidEl);
+	zoomWrapper.appendChild(mermaidEl);
+	zoomContainer.appendChild(zoomWrapper);
+	wrapper.appendChild(zoomContainer);
 
-	// Add export button
+	// Create pan/zoom handler (disable wheel zoom to avoid scroll interference)
+	const panZoomHandler = new PanZoomHandler(zoomContainer, zoomWrapper, {
+		enableWheelZoom: false,
+		enableDragPan: true,
+		enableTouchGestures: true,
+	});
+
+	// Fit content to container after a brief delay to ensure layout is complete
+	requestAnimationFrame(() => {
+		panZoomHandler.fitContent();
+	});
+
+	// Add toolbar with zoom controls and export button
 	const filename = generateFilename(sourcePath, index);
-	const button = createExportButton(svg, filename, settings);
-	wrapper.appendChild(button);
+	const toolbar = createToolbar(svg, filename, settings, panZoomHandler);
+	wrapper.appendChild(toolbar);
 }
 
 /**
@@ -184,7 +246,7 @@ function waitForSvg(mermaidEl: Element, timeout = 5000): Promise<SVGSVGElement |
 }
 
 /**
- * Processes a mermaid element to add export functionality.
+ * Processes a mermaid element to add toolbar functionality.
  */
 function processMermaidElement(
 	mermaidEl: Element,
@@ -194,13 +256,13 @@ function processMermaidElement(
 ): void {
 	void waitForSvg(mermaidEl).then((svg) => {
 		if (svg) {
-			addExportToMermaid(mermaidEl, sourcePath, index, settings);
+			addToolbarToMermaid(mermaidEl, sourcePath, index, settings);
 		}
 	});
 }
 
 /**
- * Registers the markdown post-processor for mermaid export functionality.
+ * Registers the markdown post-processor for mermaid toolbar functionality.
  * This handles Reading View.
  */
 export function registerMermaidExportPostProcessor(
@@ -228,7 +290,7 @@ export function createLivePreviewExportObserver(
 	let diagramCounter = 0;
 
 	const processElement = (el: Element): void => {
-		// Skip elements inside the standalone MermaidView (it has its own export)
+		// Skip elements inside the standalone MermaidView (it has its own controls)
 		if (isInsideMermaidView(el)) {
 			return;
 		}
@@ -237,7 +299,7 @@ export function createLivePreviewExportObserver(
 		// Structure: .cm-preview-code-block.cm-embed-block.cm-lang-mermaid > .mermaid > svg
 		if (el.matches?.(".cm-preview-code-block.cm-lang-mermaid")) {
 			const mermaidEl = el.querySelector(".mermaid");
-			if (mermaidEl && !mermaidEl.classList.contains("mermaid-export-processed")) {
+			if (mermaidEl && !mermaidEl.classList.contains("mermaid-toolbar-processed")) {
 				// Try to get source path from the active file
 				const sourcePath = app.workspace.getActiveFile()?.path ?? "";
 				processMermaidElement(mermaidEl, sourcePath, diagramCounter++, settings);
@@ -245,7 +307,7 @@ export function createLivePreviewExportObserver(
 		}
 
 		// Also check for .mermaid elements directly (Reading View structure)
-		if (el.matches?.(".mermaid") && !el.classList.contains("mermaid-export-processed")) {
+		if (el.matches?.(".mermaid") && !el.classList.contains("mermaid-toolbar-processed")) {
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
 			processMermaidElement(el, sourcePath, diagramCounter++, settings);
 		}
@@ -278,7 +340,7 @@ export function createLivePreviewExportObserver(
 
 	// Process any existing mermaid diagrams (excluding those in standalone MermaidView)
 	document.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid").forEach(processElement);
-	document.querySelectorAll(".mermaid:not(.mermaid-export-processed)").forEach((el) => {
+	document.querySelectorAll(".mermaid:not(.mermaid-toolbar-processed)").forEach((el) => {
 		if (!isInsideMermaidView(el)) {
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
 			processMermaidElement(el, sourcePath, diagramCounter++, settings);

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -97,6 +97,14 @@ function showExportMenu(
 }
 
 /**
+ * Checks if an element is inside the standalone MermaidView.
+ * We don't want to add export buttons there since it has its own export menu.
+ */
+function isInsideMermaidView(el: Element): boolean {
+	return el.closest(".mermaid-view-container") !== null;
+}
+
+/**
  * Adds export functionality to a mermaid container element.
  */
 function addExportToMermaid(
@@ -107,6 +115,11 @@ function addExportToMermaid(
 ): void {
 	// Check if we've already processed this element
 	if (mermaidEl.classList.contains("mermaid-export-processed")) {
+		return;
+	}
+
+	// Skip elements inside the standalone MermaidView (it has its own export)
+	if (isInsideMermaidView(mermaidEl)) {
 		return;
 	}
 
@@ -215,6 +228,11 @@ export function createLivePreviewExportObserver(
 	let diagramCounter = 0;
 
 	const processElement = (el: Element): void => {
+		// Skip elements inside the standalone MermaidView (it has its own export)
+		if (isInsideMermaidView(el)) {
+			return;
+		}
+
 		// Look for mermaid containers in Live Preview
 		// Structure: .cm-preview-code-block.cm-embed-block.cm-lang-mermaid > .mermaid > svg
 		if (el.matches?.(".cm-preview-code-block.cm-lang-mermaid")) {
@@ -258,11 +276,13 @@ export function createLivePreviewExportObserver(
 		subtree: true,
 	});
 
-	// Process any existing mermaid diagrams
+	// Process any existing mermaid diagrams (excluding those in standalone MermaidView)
 	document.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid").forEach(processElement);
 	document.querySelectorAll(".mermaid:not(.mermaid-export-processed)").forEach((el) => {
-		const sourcePath = app.workspace.getActiveFile()?.path ?? "";
-		processMermaidElement(el, sourcePath, diagramCounter++, settings);
+		if (!isInsideMermaidView(el)) {
+			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
+			processMermaidElement(el, sourcePath, diagramCounter++, settings);
+		}
 	});
 
 	// Return cleanup function

--- a/src/panZoom.ts
+++ b/src/panZoom.ts
@@ -1,0 +1,342 @@
+/**
+ * Options for configuring PanZoomHandler behavior.
+ */
+export interface PanZoomOptions {
+	/** Minimum scale factor (default: 0.1) */
+	minScale?: number;
+	/** Maximum scale factor (default: 5) */
+	maxScale?: number;
+	/** Enable mouse wheel zoom (default: true). Disable to avoid scroll interference. */
+	enableWheelZoom?: boolean;
+	/** Enable click-drag panning (default: true) */
+	enableDragPan?: boolean;
+	/** Enable touch gestures - pinch zoom and single-finger pan (default: true) */
+	enableTouchGestures?: boolean;
+	/** Fit content to container on initialization (default: false) */
+	fitToContainer?: boolean;
+}
+
+/**
+ * Handles pan and zoom functionality for a container element.
+ * Supports both full interactivity (wheel zoom, drag pan, touch gestures)
+ * and toolbar-only mode (buttons only, no gesture interaction).
+ */
+export class PanZoomHandler {
+	private container: HTMLElement;
+	private wrapper: HTMLElement;
+
+	private scale = 1;
+	private translateX = 0;
+	private translateY = 0;
+	private isPanning = false;
+	private didPan = false; // Track if actual movement occurred
+	private startX = 0;
+	private startY = 0;
+
+	private readonly minScale: number;
+	private readonly maxScale: number;
+	private readonly enableWheelZoom: boolean;
+	private readonly enableDragPan: boolean;
+	private readonly enableTouchGestures: boolean;
+	private readonly fitToContainer: boolean;
+
+	// Initial fit state (for reset)
+	private initialScale = 1;
+	private initialTranslateX = 0;
+	private initialTranslateY = 0;
+
+	// Touch gesture state
+	private initialPinchDistance = 0;
+	private initialPinchScale = 1;
+
+	// Event listener cleanup
+	private cleanupFns: (() => void)[] = [];
+
+	// Callback for scale changes
+	private onScaleChange?: (scale: number, translateX: number, translateY: number) => void;
+
+	constructor(container: HTMLElement, wrapper: HTMLElement, options?: PanZoomOptions) {
+		this.container = container;
+		this.wrapper = wrapper;
+
+		this.minScale = options?.minScale ?? 0.1;
+		this.maxScale = options?.maxScale ?? 5;
+		this.enableWheelZoom = options?.enableWheelZoom ?? true;
+		this.enableDragPan = options?.enableDragPan ?? true;
+		this.enableTouchGestures = options?.enableTouchGestures ?? true;
+		this.fitToContainer = options?.fitToContainer ?? false;
+
+		this.setupGestures();
+	}
+
+	/**
+	 * Calculates and applies the initial scale to fit content width within the container.
+	 * Call this after content has been added to the wrapper.
+	 */
+	fitContent(): void {
+		const containerRect = this.container.getBoundingClientRect();
+		const wrapperRect = this.wrapper.getBoundingClientRect();
+
+		if (wrapperRect.width === 0 || wrapperRect.height === 0) {
+			return;
+		}
+
+		// Calculate scale to fit content width in container (don't scale up, only down)
+		const fitScale = Math.min(containerRect.width / wrapperRect.width, 1);
+
+		// Center horizontally
+		const scaledWidth = wrapperRect.width * fitScale;
+		const translateX = (containerRect.width - scaledWidth) / 2;
+
+		// Store as initial state
+		this.initialScale = fitScale;
+		this.initialTranslateX = translateX;
+		this.initialTranslateY = 0;
+
+		// Apply
+		this.scale = fitScale;
+		this.translateX = translateX;
+		this.translateY = 0;
+		this.applyTransform();
+	}
+
+	/**
+	 * Sets a callback to be called when the scale or position changes.
+	 */
+	setOnScaleChange(callback: (scale: number, translateX: number, translateY: number) => void): void {
+		this.onScaleChange = callback;
+	}
+
+	/**
+	 * Resets zoom and pan to initial state.
+	 */
+	resetZoom(): void {
+		this.scale = this.initialScale;
+		this.translateX = this.initialTranslateX;
+		this.translateY = this.initialTranslateY;
+		this.applyTransform();
+	}
+
+	/**
+	 * Zooms in by a factor (default: 1.2x).
+	 */
+	zoomIn(factor = 1.2): void {
+		this.zoomToCenter(factor);
+	}
+
+	/**
+	 * Zooms out by a factor (default: 0.8x).
+	 */
+	zoomOut(factor = 0.8): void {
+		this.zoomToCenter(factor);
+	}
+
+	/**
+	 * Returns the current scale factor.
+	 */
+	getScale(): number {
+		return this.scale;
+	}
+
+	/**
+	 * Returns the current translation values.
+	 */
+	getTranslate(): { x: number; y: number } {
+		return { x: this.translateX, y: this.translateY };
+	}
+
+	/**
+	 * Cleans up event listeners. Call this when the handler is no longer needed.
+	 */
+	destroy(): void {
+		for (const cleanup of this.cleanupFns) {
+			cleanup();
+		}
+		this.cleanupFns = [];
+	}
+
+	private setupGestures(): void {
+		// Wheel event for zooming
+		if (this.enableWheelZoom) {
+			const handleWheel = (e: WheelEvent): void => {
+				e.preventDefault();
+
+				const rect = this.container.getBoundingClientRect();
+				const mouseX = e.clientX - rect.left;
+				const mouseY = e.clientY - rect.top;
+
+				// Calculate zoom
+				const zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
+				const newScale = Math.min(
+					this.maxScale,
+					Math.max(this.minScale, this.scale * zoomFactor)
+				);
+
+				// Zoom toward mouse position
+				const scaleChange = newScale / this.scale;
+				this.translateX = mouseX - scaleChange * (mouseX - this.translateX);
+				this.translateY = mouseY - scaleChange * (mouseY - this.translateY);
+				this.scale = newScale;
+
+				this.applyTransform();
+			};
+			this.container.addEventListener("wheel", handleWheel, { passive: false });
+			this.cleanupFns.push(() => this.container.removeEventListener("wheel", handleWheel));
+		}
+
+		// Mouse events for panning
+		if (this.enableDragPan) {
+			const handleMouseDown = (e: MouseEvent): void => {
+				if (e.button !== 0) return; // Only left click
+				this.isPanning = true;
+				this.didPan = false; // Reset pan tracking
+				this.startX = e.clientX - this.translateX;
+				this.startY = e.clientY - this.translateY;
+				this.container.classList.add("mermaid-view-panning");
+			};
+			this.container.addEventListener("mousedown", handleMouseDown);
+			this.cleanupFns.push(() => this.container.removeEventListener("mousedown", handleMouseDown));
+
+			const handleMouseMove = (e: MouseEvent): void => {
+				if (!this.isPanning) return;
+				this.didPan = true; // Actual movement occurred
+				this.translateX = e.clientX - this.startX;
+				this.translateY = e.clientY - this.startY;
+				this.applyTransform();
+			};
+			this.container.addEventListener("mousemove", handleMouseMove);
+			this.cleanupFns.push(() => this.container.removeEventListener("mousemove", handleMouseMove));
+
+			const handleMouseUp = (): void => {
+				this.isPanning = false;
+				this.container.classList.remove("mermaid-view-panning");
+			};
+			this.container.addEventListener("mouseup", handleMouseUp);
+			this.cleanupFns.push(() => this.container.removeEventListener("mouseup", handleMouseUp));
+
+			const handleMouseLeave = (): void => {
+				this.isPanning = false;
+				this.container.classList.remove("mermaid-view-panning");
+			};
+			this.container.addEventListener("mouseleave", handleMouseLeave);
+			this.cleanupFns.push(() => this.container.removeEventListener("mouseleave", handleMouseLeave));
+
+			// Double-click to reset (only makes sense if pan is enabled)
+			const handleDblClick = (): void => {
+				this.resetZoom();
+			};
+			this.container.addEventListener("dblclick", handleDblClick);
+			this.cleanupFns.push(() => this.container.removeEventListener("dblclick", handleDblClick));
+
+			// Prevent click from navigating if we just panned
+			const handleClick = (e: MouseEvent): void => {
+				if (this.didPan) {
+					e.preventDefault();
+					e.stopPropagation();
+					this.didPan = false;
+				}
+			};
+			this.container.addEventListener("click", handleClick, true); // Use capture phase
+			this.cleanupFns.push(() => this.container.removeEventListener("click", handleClick, true));
+		}
+
+		// Touch events for mobile pan/zoom
+		if (this.enableTouchGestures) {
+			const handleTouchStart = (e: TouchEvent): void => {
+				const touch1 = e.touches[0];
+				const touch2 = e.touches[1];
+
+				if (e.touches.length === 2 && touch1 && touch2) {
+					// Pinch zoom start
+					this.initialPinchDistance = Math.hypot(
+						touch2.clientX - touch1.clientX,
+						touch2.clientY - touch1.clientY
+					);
+					this.initialPinchScale = this.scale;
+				} else if (e.touches.length === 1 && touch1) {
+					// Single touch pan
+					this.isPanning = true;
+					this.didPan = false; // Reset pan tracking
+					this.startX = touch1.clientX - this.translateX;
+					this.startY = touch1.clientY - this.translateY;
+					this.container.classList.add("mermaid-view-panning");
+				}
+			};
+			this.container.addEventListener("touchstart", handleTouchStart);
+			this.cleanupFns.push(() => this.container.removeEventListener("touchstart", handleTouchStart));
+
+			const handleTouchMove = (e: TouchEvent): void => {
+				e.preventDefault();
+
+				const touch1 = e.touches[0];
+				const touch2 = e.touches[1];
+
+				if (e.touches.length === 2 && touch1 && touch2) {
+					// Pinch zoom
+					this.didPan = true; // Treat pinch as interaction that prevents navigation
+					const currentDistance = Math.hypot(
+						touch2.clientX - touch1.clientX,
+						touch2.clientY - touch1.clientY
+					);
+
+					const scaleRatio = currentDistance / this.initialPinchDistance;
+					const newScale = Math.min(
+						this.maxScale,
+						Math.max(this.minScale, this.initialPinchScale * scaleRatio)
+					);
+
+					// Zoom toward pinch center
+					const rect = this.container.getBoundingClientRect();
+					const centerX = (touch1.clientX + touch2.clientX) / 2 - rect.left;
+					const centerY = (touch1.clientY + touch2.clientY) / 2 - rect.top;
+
+					const scaleChange = newScale / this.scale;
+					this.translateX = centerX - scaleChange * (centerX - this.translateX);
+					this.translateY = centerY - scaleChange * (centerY - this.translateY);
+					this.scale = newScale;
+
+					this.applyTransform();
+				} else if (e.touches.length === 1 && touch1 && this.isPanning) {
+					// Single touch pan
+					this.didPan = true;
+					this.translateX = touch1.clientX - this.startX;
+					this.translateY = touch1.clientY - this.startY;
+					this.applyTransform();
+				}
+			};
+			this.container.addEventListener("touchmove", handleTouchMove, { passive: false });
+			this.cleanupFns.push(() => this.container.removeEventListener("touchmove", handleTouchMove));
+
+			const handleTouchEnd = (): void => {
+				this.isPanning = false;
+				this.container.classList.remove("mermaid-view-panning");
+			};
+			this.container.addEventListener("touchend", handleTouchEnd);
+			this.cleanupFns.push(() => this.container.removeEventListener("touchend", handleTouchEnd));
+		}
+	}
+
+	private applyTransform(): void {
+		this.wrapper.style.transform = `translate(${this.translateX}px, ${this.translateY}px) scale(${this.scale})`;
+		this.onScaleChange?.(this.scale, this.translateX, this.translateY);
+	}
+
+	private zoomToCenter(factor: number): void {
+		const newScale = Math.min(
+			this.maxScale,
+			Math.max(this.minScale, this.scale * factor)
+		);
+
+		// Zoom toward center of container
+		const rect = this.container.getBoundingClientRect();
+		const centerX = rect.width / 2;
+		const centerY = rect.height / 2;
+
+		const scaleChange = newScale / this.scale;
+		this.translateX = centerX - scaleChange * (centerX - this.translateX);
+		this.translateY = centerY - scaleChange * (centerY - this.translateY);
+		this.scale = newScale;
+
+		this.applyTransform();
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -228,11 +228,10 @@
 /* Toolbar for embedded diagrams */
 .mermaid-toolbar {
 	position: absolute;
-	top: 8px;
-	right: 40px;
+	top: var(--size-4-2);
+	inset-inline-end: var(--size-4-2);
 	display: flex;
-	flex-direction: row;
-	gap: 0;
+	flex-direction: column;
 	background-color: var(--background-primary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: var(--radius-s);
@@ -248,21 +247,23 @@
 }
 
 .mermaid-toolbar-button {
-	width: 28px;
-	height: 28px;
-	padding: 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding: var(--size-4-2);
 	background-color: transparent;
 	border: none;
-	border-right: 1px solid var(--background-modifier-border);
+	border-bottom: 1px solid var(--background-modifier-border);
+	border-radius: 0;
+	box-shadow: none;
 	cursor: pointer;
 	color: var(--text-muted);
+	--icon-size: var(--icon-s);
+	--icon-stroke: var(--icon-s-stroke-width);
 }
 
 .mermaid-toolbar-button:last-child {
-	border-right: none;
+	border-bottom: none;
 }
 
 .mermaid-toolbar-button:hover {
@@ -271,6 +272,7 @@
 }
 
 .mermaid-toolbar-button svg {
-	width: 16px;
-	height: 16px;
+	width: var(--icon-size);
+	height: var(--icon-size);
+	stroke-width: var(--icon-stroke);
 }

--- a/styles.css
+++ b/styles.css
@@ -195,3 +195,43 @@
 	max-width: 100%;
 	height: auto;
 }
+
+/* Export button for mermaid diagrams in markdown */
+.mermaid-export-wrapper {
+	position: relative;
+	display: inline-block;
+}
+
+.mermaid-export-button {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: var(--radius-s);
+	cursor: pointer;
+	opacity: 0;
+	transition: opacity 150ms ease-in-out;
+	z-index: 10;
+	color: var(--text-muted);
+}
+
+.mermaid-export-wrapper:hover .mermaid-export-button {
+	opacity: 1;
+}
+
+.mermaid-export-button:hover {
+	background-color: var(--interactive-hover);
+	color: var(--text-normal);
+}
+
+.mermaid-export-button svg {
+	width: 16px;
+	height: 16px;
+}

--- a/styles.css
+++ b/styles.css
@@ -196,42 +196,80 @@
 	height: auto;
 }
 
-/* Export button for mermaid diagrams in markdown */
-.mermaid-export-wrapper {
+/* Embedded mermaid diagram wrapper with toolbar */
+.mermaid-diagram-wrapper {
 	position: relative;
-	display: inline-block;
+	width: 100%;
 }
 
-.mermaid-export-button {
+/* Zoom container for embedded diagrams */
+.mermaid-zoom-container {
+	overflow: hidden;
+	width: 100%;
+	cursor: grab;
+	touch-action: none;
+}
+
+.mermaid-zoom-container.mermaid-view-panning {
+	cursor: grabbing;
+}
+
+/* Zoom wrapper for embedded diagrams (receives transforms) */
+.mermaid-embedded-zoom-wrapper {
+	transform-origin: 0 0;
+	will-change: transform;
+}
+
+/* Ensure mermaid SVG isn't constrained when zooming */
+.mermaid-embedded-zoom-wrapper .mermaid svg {
+	max-width: none;
+}
+
+/* Toolbar for embedded diagrams */
+.mermaid-toolbar {
 	position: absolute;
 	top: 8px;
-	right: 8px;
+	right: 40px;
+	display: flex;
+	flex-direction: row;
+	gap: 0;
+	background-color: var(--background-primary);
+	border: 1px solid var(--background-modifier-border);
+	border-radius: var(--radius-s);
+	overflow: hidden;
+	opacity: 0;
+	transition: opacity 150ms ease-in-out;
+	z-index: 10;
+}
+
+.mermaid-diagram-wrapper:hover .mermaid-toolbar {
+	opacity: 1;
+}
+
+.mermaid-toolbar-button {
 	width: 28px;
 	height: 28px;
 	padding: 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background-color: var(--background-primary);
-	border: 1px solid var(--background-modifier-border);
-	border-radius: var(--radius-s);
+	background-color: transparent;
+	border: none;
+	border-right: 1px solid var(--background-modifier-border);
 	cursor: pointer;
-	opacity: 0;
-	transition: opacity 150ms ease-in-out;
-	z-index: 10;
 	color: var(--text-muted);
 }
 
-.mermaid-export-wrapper:hover .mermaid-export-button {
-	opacity: 1;
+.mermaid-toolbar-button:last-child {
+	border-right: none;
 }
 
-.mermaid-export-button:hover {
+.mermaid-toolbar-button:hover {
 	background-color: var(--interactive-hover);
 	color: var(--text-normal);
 }
 
-.mermaid-export-button svg {
+.mermaid-toolbar-button svg {
 	width: 16px;
 	height: 16px;
 }

--- a/styles.css
+++ b/styles.css
@@ -242,7 +242,8 @@
 	z-index: 10;
 }
 
-.mermaid-diagram-wrapper:hover .mermaid-toolbar {
+.mermaid-diagram-wrapper:hover .mermaid-toolbar,
+.mermaid-diagram-wrapper.is-mobile .mermaid-toolbar {
 	opacity: 1;
 }
 


### PR DESCRIPTION
Bring the "Mermaid View" features like Export/Pan/Zoom to the embedded modes.

**Markdown `mermaid` code block (Obsidian default)**

<img width="816" height="665" alt="Screenshot 2026-02-05 at 19 22 18" src="https://github.com/user-attachments/assets/704f9e27-7e73-4a6f-be54-0be21e077d3d" />

**Markdown `![[file]]` code (provided by this Plugin)**

<img width="790" height="638" alt="Screenshot 2026-02-05 at 19 22 08" src="https://github.com/user-attachments/assets/cbd9e568-976f-491a-a21d-b718daa91ace" />

