### PR TITLE
Add click-to-copy feature

### DIFF
--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -318,12 +318,34 @@ export class MermaidView extends TextFileView {
 		// Export control group
 		const exportGroup = controls.createDiv({ cls: "mermaid-zoom-control-group" });
 
+		const copyBtn = exportGroup.createDiv({
+			cls: "mermaid-zoom-control-item",
+			attr: { "aria-label": "Copy diagram code" },
+		});
+		setIcon(copyBtn, "copy");
+		copyBtn.addEventListener("click", () => this.copyDiagramCode(copyBtn));
+
 		const exportBtn = exportGroup.createDiv({
 			cls: "mermaid-zoom-control-item",
 			attr: { "aria-label": "Export diagram" },
 		});
 		setIcon(exportBtn, "download");
 		exportBtn.addEventListener("click", (event) => this.showExportMenu(event));
+	}
+
+	// ========== Copy Methods ==========
+
+	private copyDiagramCode(btn: HTMLElement): void {
+		const source = (this.data ?? "").trim();
+		if (!source) {
+			new Notice("No diagram code to copy.");
+			return;
+		}
+		void navigator.clipboard.writeText(source).then(() => {
+			new Notice("Diagram code copied to clipboard");
+			setIcon(btn, "check");
+			setTimeout(() => setIcon(btn, "copy"), 2000);
+		});
 	}
 
 	// ========== Export Methods ==========

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -106,13 +106,17 @@ export class EmbedHandler {
 		if (!linkedFile) return;
 
 		const content = await this.app.vault.read(linkedFile);
+		const trimmedContent = content.trim();
 
 		// Mark as processed and update classes
 		container.empty();
 		container.addClass("mermaid-embed");
 		container.removeClass("file-embed", "mod-generic");
+		// Preserve original diagram code so toolbar copy can still access it after SVG render.
+		container.dataset.mermaidSource = trimmedContent;
+		container.dataset.mermaidSourcePath = linkedFile.path;
 
-		const mermaidMarkdown = "```mermaid\n" + content.trim() + "\n```";
+		const mermaidMarkdown = "```mermaid\n" + trimmedContent + "\n```";
 
 		const embedComponent = new Component();
 		addChild(embedComponent);

--- a/src/markdownExport.test.ts
+++ b/src/markdownExport.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { extractMermaidBlocks, generateFilename } from "./markdownExport";
+
+describe("generateFilename", () => {
+	it("returns 'diagram' when sourcePath is empty and index is 0", () => {
+		expect(generateFilename("", 0)).toBe("diagram");
+	});
+
+	it("returns 'diagram-N' when sourcePath is empty and index > 0", () => {
+		expect(generateFilename("", 1)).toBe("diagram-2");
+		expect(generateFilename("", 2)).toBe("diagram-3");
+	});
+
+	it("uses basename without extension when sourcePath is set and index is 0", () => {
+		expect(generateFilename("folder/file.mmd", 0)).toBe("file");
+		expect(generateFilename("folder/file.mermaid", 0)).toBe("file");
+		expect(generateFilename("file.mmd", 0)).toBe("file");
+	});
+
+	it("appends index to basename when index > 0", () => {
+		expect(generateFilename("folder/diagram.mmd", 1)).toBe("diagram-2");
+		expect(generateFilename("a/b/c.mermaid", 2)).toBe("c-3");
+	});
+
+	it("falls back to 'diagram' when path has trailing slash (empty filename)", () => {
+		expect(generateFilename("foo/bar/", 0)).toBe("diagram");
+	});
+});
+
+describe("extractMermaidBlocks", () => {
+	it("returns empty array for empty lines", () => {
+		expect(extractMermaidBlocks([])).toEqual([]);
+	});
+
+	it("returns empty array when there are no mermaid blocks", () => {
+		expect(extractMermaidBlocks(["# Heading", "Some text"])).toEqual([]);
+	});
+
+	it("ignores non-mermaid code blocks", () => {
+		const lines = ["```js", "const x = 1;", "```"];
+		expect(extractMermaidBlocks(lines)).toEqual([]);
+	});
+
+	it("extracts a single mermaid block", () => {
+		const lines = ["```mermaid", "graph TD", "  A --> B", "```"];
+		expect(extractMermaidBlocks(lines)).toEqual(["graph TD\n  A --> B"]);
+	});
+
+	it("extracts multiple mermaid blocks", () => {
+		const lines = [
+			"```mermaid",
+			"graph TD",
+			"A --> B",
+			"```",
+			"text",
+			"```mermaid",
+			"flowchart LR",
+			"C --> D",
+			"```",
+		];
+		expect(extractMermaidBlocks(lines)).toEqual([
+			"graph TD\nA --> B",
+			"flowchart LR\nC --> D",
+		]);
+	});
+
+	it("recognizes mermaid block with different casing", () => {
+		const lines = ["```Mermaid", "graph TD", "A --> B", "```"];
+		expect(extractMermaidBlocks(lines)).toEqual(["graph TD\nA --> B"]);
+	});
+
+	it("returns empty block for mermaid fence with no content", () => {
+		const lines = ["```mermaid", "```"];
+		expect(extractMermaidBlocks(lines)).toEqual([""]);
+	});
+
+	it("trims leading and trailing whitespace of the block", () => {
+		const lines = ["```mermaid", "  graph TD  ", "  A --> B  ", "```"];
+		expect(extractMermaidBlocks(lines)).toEqual(["graph TD  \n  A --> B"]);
+	});
+});

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -1,4 +1,4 @@
-import { App, MarkdownPostProcessorContext, Menu, Platform, setIcon } from "obsidian";
+import { App, MarkdownPostProcessorContext, Menu, Notice, Platform, TFile, setIcon } from "obsidian";
 import { exportAsSvg, exportAsPng } from "./export";
 import { PanZoomHandler } from "./panZoom";
 import type { MermaidViewSettings, PngBackground } from "./settings";
@@ -42,10 +42,14 @@ function generateFilename(sourcePath: string, index: number): string {
  * Creates the toolbar with zoom controls and export button.
  */
 function createToolbar(
+	app: App,
 	svg: SVGSVGElement,
 	filename: string,
 	settings: MermaidViewSettings,
-	panZoomHandler: PanZoomHandler
+	panZoomHandler: PanZoomHandler,
+	sourceCode: string,
+	sourcePath: string,
+	index: number
 ): HTMLElement {
 	const toolbar = document.createElement("div");
 	toolbar.className = "mermaid-toolbar";
@@ -92,6 +96,53 @@ function createToolbar(
 	// Export control group
 	const exportGroup = document.createElement("div");
 	exportGroup.className = "mermaid-toolbar-group";
+
+	const copyBtn = document.createElement("button");
+	copyBtn.className = "mermaid-toolbar-button";
+	copyBtn.setAttribute("aria-label", "Copy diagram code");
+	setIcon(copyBtn, "copy");
+	let resolvedSourceCode = sourceCode.trim();
+	copyBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		void (async () => {
+			if (!resolvedSourceCode) {
+				const containerSource = svg
+					.closest(".mermaid")
+					?.getAttribute("data-mermaid-source")
+					?.trim();
+				if (containerSource) {
+					resolvedSourceCode = containerSource;
+				}
+			}
+
+			if (!resolvedSourceCode) {
+				const fallbackPath = sourcePath || (app.workspace.getActiveFile()?.path ?? "");
+				if (fallbackPath) {
+					const sources = await getMermaidSourcesFromFile(app, fallbackPath);
+					const matchedSource = sources[index]?.trim();
+					if (matchedSource) {
+						resolvedSourceCode = matchedSource;
+					} else if (sources.length > 0) {
+						resolvedSourceCode = (sources[0] ?? "").trim();
+					}
+				}
+			}
+
+			if (!resolvedSourceCode) {
+				new Notice("Diagram code not available.");
+				return;
+			}
+
+			await navigator.clipboard.writeText(resolvedSourceCode);
+			new Notice("Diagram code copied to clipboard");
+			setIcon(copyBtn, "check");
+			setTimeout(() => setIcon(copyBtn, "copy"), 2000);
+		})().catch(() => {
+			new Notice("Unable to copy diagram code.");
+		});
+	});
+	exportGroup.appendChild(copyBtn);
 
 	const exportBtn = document.createElement("button");
 	exportBtn.className = "mermaid-toolbar-button";
@@ -156,10 +207,12 @@ function isInsideMermaidView(el: Element): boolean {
  * Adds pan/zoom and export functionality to a mermaid container element.
  */
 function addToolbarToMermaid(
+	app: App,
 	mermaidEl: Element,
 	sourcePath: string,
 	index: number,
-	settings: MermaidViewSettings
+	settings: MermaidViewSettings,
+	sourceCode: string
 ): void {
 	// Check if we've already processed this element
 	if (mermaidEl.classList.contains("mermaid-toolbar-processed")) {
@@ -217,7 +270,16 @@ function addToolbarToMermaid(
 
 	// Add toolbar with zoom controls and export button
 	const filename = generateFilename(sourcePath, index);
-	const toolbar = createToolbar(svg, filename, settings, panZoomHandler);
+	const toolbar = createToolbar(
+		app,
+		svg,
+		filename,
+		settings,
+		panZoomHandler,
+		sourceCode,
+		sourcePath,
+		index
+	);
 	wrapper.appendChild(toolbar);
 }
 
@@ -257,17 +319,155 @@ function waitForSvg(mermaidEl: Element, timeout = 5000): Promise<SVGSVGElement |
 }
 
 /**
+ * Captures the mermaid source code from the element before SVG rendering
+ * replaces the text content, with fallbacks for when SVG is already rendered.
+ */
+function captureMermaidSource(mermaidEl: Element): string {
+	// Embed mode: source is preserved by EmbedHandler on the container element.
+	const embedContainer = mermaidEl.closest<HTMLElement>(".mermaid-embed");
+	if (embedContainer?.dataset.mermaidSource) {
+		return embedContainer.dataset.mermaidSource.trim();
+	}
+
+	// If SVG hasn't rendered yet, text content is the source
+	if (!mermaidEl.querySelector("svg")) {
+		return mermaidEl.textContent?.trim() ?? "";
+	}
+
+	// Fallback: look for <code> element in parent block (Reading View)
+	const readingBlock = mermaidEl.closest(".el-pre, .block-language-mermaid");
+	if (readingBlock) {
+		const codeEl = readingBlock.querySelector("pre > code, code.language-mermaid, code");
+		if (codeEl?.textContent?.trim()) {
+			return codeEl.textContent.trim();
+		}
+	}
+
+	// Fallback: extract from Live Preview code block structure
+	const cmBlock = mermaidEl.closest(".cm-preview-code-block");
+	if (cmBlock) {
+		const lines: string[] = [];
+		cmBlock.querySelectorAll(".cm-line").forEach((line) => {
+			lines.push(line.textContent ?? "");
+		});
+		if (lines.length > 0) {
+			return lines.join("\n").trim();
+		}
+	}
+
+	return "";
+}
+
+/**
+ * Extracts mermaid source from a Live Preview code block container.
+ */
+function captureSourceFromLivePreviewBlock(cmBlock: Element): string {
+	const lines: string[] = [];
+	cmBlock.querySelectorAll(".cm-line").forEach((line) => {
+		lines.push(line.textContent ?? "");
+	});
+
+	if (lines.length === 0) {
+		return "";
+	}
+
+	// If fences are present, extract content inside ```mermaid ... ```
+	const fenced = extractMermaidBlocks(lines);
+	if (fenced.length > 0) {
+		return fenced[0] ?? "";
+	}
+
+	// Some Live Preview structures expose only block content lines.
+	return lines.join("\n").trim();
+}
+
+/**
+ * Extracts mermaid code blocks from markdown lines.
+ */
+function extractMermaidBlocks(lines: string[]): string[] {
+	const blocks: string[] = [];
+	let inMermaidBlock = false;
+	let currentBlock: string[] = [];
+
+	for (const line of lines) {
+		if (!inMermaidBlock) {
+			const fenceMatch = line.match(/^```([\w-]+)?\s*$/);
+			if (fenceMatch && fenceMatch[1]?.toLowerCase() === "mermaid") {
+				inMermaidBlock = true;
+				currentBlock = [];
+			}
+			continue;
+		}
+
+		if (/^```\s*$/.test(line)) {
+			blocks.push(currentBlock.join("\n").trim());
+			inMermaidBlock = false;
+			currentBlock = [];
+			continue;
+		}
+
+		currentBlock.push(line);
+	}
+
+	return blocks;
+}
+
+/**
+ * Extracts mermaid source blocks from a markdown file.
+ */
+async function getMermaidSourcesFromFile(app: App, sourcePath: string): Promise<string[]> {
+	const abstractFile = app.vault.getAbstractFileByPath(sourcePath);
+	if (!(abstractFile instanceof TFile)) {
+		return [];
+	}
+
+	const fileContent = await app.vault.read(abstractFile);
+	return extractMermaidBlocks(fileContent.split(/\r?\n/));
+}
+
+/**
+ * Extracts mermaid source code from the current rendered section using source lines.
+ */
+async function getMermaidSourcesFromSection(
+	app: App,
+	containerEl: HTMLElement,
+	ctx: MarkdownPostProcessorContext
+): Promise<string[]> {
+	const sectionInfo = ctx.getSectionInfo(containerEl);
+	if (!sectionInfo || !ctx.sourcePath) {
+		return [];
+	}
+
+	const abstractFile = app.vault.getAbstractFileByPath(ctx.sourcePath);
+	if (!(abstractFile instanceof TFile)) {
+		return [];
+	}
+	const fileContent = await app.vault.read(abstractFile);
+	const lines = fileContent.split(/\r?\n/);
+	const sectionLines = lines.slice(sectionInfo.lineStart, sectionInfo.lineEnd + 1);
+	return extractMermaidBlocks(sectionLines);
+}
+
+/**
  * Processes a mermaid element to add toolbar functionality.
  */
 function processMermaidElement(
+	app: App,
 	mermaidEl: Element,
 	sourcePath: string,
 	index: number,
-	settings: MermaidViewSettings
+	settings: MermaidViewSettings,
+	fallbackSourceCode = ""
 ): void {
+	// Capture source code before SVG rendering replaces text content
+	const sourceCode = captureMermaidSource(mermaidEl) || fallbackSourceCode;
+	if (sourceCode) {
+		(mermaidEl as HTMLElement).dataset.mermaidSource = sourceCode;
+	}
+
 	void waitForSvg(mermaidEl).then((svg) => {
 		if (svg) {
-			addToolbarToMermaid(mermaidEl, sourcePath, index, settings);
+			addToolbarToMermaid(app, mermaidEl, sourcePath, index, settings, sourceCode);
 		}
 	});
 }
@@ -283,9 +483,32 @@ export function registerMermaidExportPostProcessor(
 ): void {
 	register((el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
 		const mermaidElements = el.querySelectorAll(".mermaid");
+		let sectionSourcesPromise: Promise<string[]> | null = null;
+
+		const getSectionSources = async (): Promise<string[]> => {
+			if (!sectionSourcesPromise) {
+				sectionSourcesPromise = getMermaidSourcesFromSection(app, el, ctx);
+			}
+			return sectionSourcesPromise;
+		};
 
 		mermaidElements.forEach((mermaidEl, index) => {
-			processMermaidElement(mermaidEl, ctx.sourcePath, index, settings);
+			const directSource = captureMermaidSource(mermaidEl);
+			if (directSource) {
+				processMermaidElement(app, mermaidEl, ctx.sourcePath, index, settings, directSource);
+				return;
+			}
+
+			void getSectionSources().then((sources) => {
+				processMermaidElement(
+					app,
+					mermaidEl,
+					ctx.sourcePath,
+					index,
+					settings,
+					sources[index] ?? ""
+				);
+			});
 		});
 	});
 }
@@ -313,14 +536,31 @@ export function createLivePreviewExportObserver(
 			if (mermaidEl && !mermaidEl.classList.contains("mermaid-toolbar-processed")) {
 				// Try to get source path from the active file
 				const sourcePath = app.workspace.getActiveFile()?.path ?? "";
-				processMermaidElement(mermaidEl, sourcePath, diagramCounter++, settings);
+				const livePreviewSource = captureSourceFromLivePreviewBlock(el);
+				processMermaidElement(
+					app,
+					mermaidEl,
+					sourcePath,
+					diagramCounter++,
+					settings,
+					livePreviewSource
+				);
 			}
 		}
 
 		// Also check for .mermaid elements directly (Reading View structure)
 		if (el.matches?.(".mermaid") && !el.classList.contains("mermaid-toolbar-processed")) {
+			const cmBlock = el.closest(".cm-preview-code-block.cm-lang-mermaid");
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
-			processMermaidElement(el, sourcePath, diagramCounter++, settings);
+			const livePreviewSource = cmBlock ? captureSourceFromLivePreviewBlock(cmBlock) : "";
+			processMermaidElement(
+				app,
+				el,
+				sourcePath,
+				diagramCounter++,
+				settings,
+				livePreviewSource
+			);
 		}
 	};
 
@@ -353,8 +593,17 @@ export function createLivePreviewExportObserver(
 	document.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid").forEach(processElement);
 	document.querySelectorAll(".mermaid:not(.mermaid-toolbar-processed)").forEach((el) => {
 		if (!isInsideMermaidView(el)) {
+			const cmBlock = el.closest(".cm-preview-code-block.cm-lang-mermaid");
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
-			processMermaidElement(el, sourcePath, diagramCounter++, settings);
+			const livePreviewSource = cmBlock ? captureSourceFromLivePreviewBlock(cmBlock) : "";
+			processMermaidElement(
+				app,
+				el,
+				sourcePath,
+				diagramCounter++,
+				settings,
+				livePreviewSource
+			);
 		}
 	});
 

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -27,22 +27,22 @@ function resolveBackgroundColor(setting: PngBackground): string {
 /**
  * Generates a filename for the export based on the source file path or a default.
  */
-function generateFilename(sourcePath: string, index: number): string {
-	if (!sourcePath) {
-		return index > 0 ? `diagram-${index + 1}` : "diagram";
+export function generateFilename(sourcePath: string, index: number): string {
+	let base = "diagram";
+	if (sourcePath) {
+		const parts = sourcePath.split("/");
+		const filename = parts[parts.length - 1];
+		if (filename) {
+			base = filename.replace(/\.[^.]+$/, "");
+		}
 	}
-
-	const parts = sourcePath.split("/");
-	const filename = parts[parts.length - 1] || "diagram";
-	const basename = filename.replace(/\.[^.]+$/, "");
-
-	return index > 0 ? `${basename}-${index + 1}` : basename;
+	return index > 0 ? `${base}-${index + 1}` : base;
 }
 
 /**
  * Extracts mermaid code blocks from markdown lines.
  */
-function extractMermaidBlocks(lines: string[]): string[] {
+export function extractMermaidBlocks(lines: string[]): string[] {
 	const blocks: string[] = [];
 	let inMermaidBlock = false;
 	let currentBlock: string[] = [];

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -3,6 +3,9 @@ import { exportAsSvg, exportAsPng } from "./export";
 import { PanZoomHandler } from "./panZoom";
 import type { MermaidViewSettings, PngBackground } from "./settings";
 
+const MERMAID_TOOLBAR_PROCESSED_CLASS = "mermaid-toolbar-processed";
+const processingMermaidElements = new WeakSet<Element>();
+
 /**
  * Resolves the background color setting to an actual color value.
  */
@@ -29,135 +32,182 @@ function generateFilename(sourcePath: string, index: number): string {
 		return index > 0 ? `diagram-${index + 1}` : "diagram";
 	}
 
-	// Extract basename without extension
 	const parts = sourcePath.split("/");
 	const filename = parts[parts.length - 1] || "diagram";
 	const basename = filename.replace(/\.[^.]+$/, "");
 
-	// Add index suffix if there might be multiple diagrams
 	return index > 0 ? `${basename}-${index + 1}` : basename;
 }
 
 /**
- * Creates the toolbar with zoom controls and export button.
+ * Extracts mermaid code blocks from markdown lines.
  */
-function createToolbar(
+function extractMermaidBlocks(lines: string[]): string[] {
+	const blocks: string[] = [];
+	let inMermaidBlock = false;
+	let currentBlock: string[] = [];
+
+	for (const line of lines) {
+		if (!inMermaidBlock) {
+			const fenceMatch = line.match(/^```([\w-]+)?\s*$/);
+			if (fenceMatch && fenceMatch[1]?.toLowerCase() === "mermaid") {
+				inMermaidBlock = true;
+				currentBlock = [];
+			}
+			continue;
+		}
+
+		if (/^```\s*$/.test(line)) {
+			blocks.push(currentBlock.join("\n").trim());
+			inMermaidBlock = false;
+			currentBlock = [];
+			continue;
+		}
+
+		currentBlock.push(line);
+	}
+
+	return blocks;
+}
+
+/**
+ * Extracts Mermaid source from a Live Preview code block container.
+ */
+function captureSourceFromLivePreviewBlock(cmBlock: Element): string {
+	const lines: string[] = [];
+	cmBlock.querySelectorAll(".cm-line").forEach((line) => {
+		lines.push(line.textContent ?? "");
+	});
+
+	if (lines.length === 0) {
+		return "";
+	}
+
+	const fencedBlocks = extractMermaidBlocks(lines);
+	if (fencedBlocks.length > 0) {
+		return fencedBlocks[0] ?? "";
+	}
+
+	return lines.join("\n").trim();
+}
+
+/**
+ * Extracts Mermaid source from Reading View code block containers.
+ */
+function captureSourceFromReadingBlock(mermaidEl: Element): string {
+	const readingBlock = mermaidEl.closest(".el-pre, .block-language-mermaid");
+	if (!readingBlock) {
+		return "";
+	}
+
+	const codeEl = readingBlock.querySelector("pre > code, code.language-mermaid, code");
+	return codeEl?.textContent?.trim() ?? "";
+}
+
+/**
+ * Captures source from surrounding DOM before relying on file fallbacks.
+ */
+function captureMermaidSource(mermaidEl: Element): string {
+	const ownSource = (mermaidEl as HTMLElement).dataset.mermaidSource?.trim();
+	if (ownSource) {
+		return ownSource;
+	}
+
+	const embedContainer = mermaidEl.closest<HTMLElement>(".mermaid-embed");
+	const embedSource = embedContainer?.dataset.mermaidSource?.trim();
+	if (embedSource) {
+		return embedSource;
+	}
+
+	const readingSource = captureSourceFromReadingBlock(mermaidEl);
+	if (readingSource) {
+		return readingSource;
+	}
+
+	const cmBlock = mermaidEl.closest(".cm-preview-code-block.cm-lang-mermaid");
+	if (cmBlock) {
+		const livePreviewSource = captureSourceFromLivePreviewBlock(cmBlock);
+		if (livePreviewSource) {
+			return livePreviewSource;
+		}
+	}
+
+	if (!mermaidEl.querySelector("svg")) {
+		return mermaidEl.textContent?.trim() ?? "";
+	}
+
+	return "";
+}
+
+/**
+ * Reads Mermaid code blocks from the full source file.
+ */
+async function getMermaidSourcesFromFile(app: App, sourcePath: string): Promise<string[]> {
+	const abstractFile = app.vault.getAbstractFileByPath(sourcePath);
+	if (!(abstractFile instanceof TFile)) {
+		return [];
+	}
+
+	const fileContent = await app.vault.read(abstractFile);
+	return extractMermaidBlocks(fileContent.split(/\r?\n/));
+}
+
+/**
+ * Reads Mermaid code blocks from the markdown section currently being rendered.
+ */
+async function getMermaidSourcesFromSection(
 	app: App,
-	svg: SVGSVGElement,
-	filename: string,
-	settings: MermaidViewSettings,
-	panZoomHandler: PanZoomHandler,
-	sourceCode: string,
+	containerEl: HTMLElement,
+	ctx: MarkdownPostProcessorContext
+): Promise<string[]> {
+	const sectionInfo = ctx.getSectionInfo(containerEl);
+	if (!sectionInfo || !ctx.sourcePath) {
+		return [];
+	}
+
+	const abstractFile = app.vault.getAbstractFileByPath(ctx.sourcePath);
+	if (!(abstractFile instanceof TFile)) {
+		return [];
+	}
+
+	const fileContent = await app.vault.read(abstractFile);
+	const lines = fileContent.split(/\r?\n/);
+	const sectionLines = lines.slice(sectionInfo.lineStart, sectionInfo.lineEnd + 1);
+	return extractMermaidBlocks(sectionLines);
+}
+
+/**
+ * Resolves source for copy action with deterministic fallback order.
+ */
+async function resolveSourceCode(
+	app: App,
+	mermaidEl: Element,
+	seedSourceCode: string,
 	sourcePath: string,
 	index: number
-): HTMLElement {
-	const toolbar = document.createElement("div");
-	toolbar.className = "mermaid-toolbar";
+): Promise<string> {
+	const seed = seedSourceCode.trim();
+	if (seed) {
+		return seed;
+	}
 
-	// Zoom control group
-	const zoomGroup = document.createElement("div");
-	zoomGroup.className = "mermaid-toolbar-group";
+	const domSource = captureMermaidSource(mermaidEl);
+	if (domSource) {
+		return domSource;
+	}
 
-	const zoomInBtn = document.createElement("button");
-	zoomInBtn.className = "mermaid-toolbar-button";
-	zoomInBtn.setAttribute("aria-label", "Zoom in");
-	setIcon(zoomInBtn, "plus");
-	zoomInBtn.addEventListener("click", (e) => {
-		e.preventDefault();
-		e.stopPropagation();
-		panZoomHandler.zoomIn();
-	});
-	zoomGroup.appendChild(zoomInBtn);
+	const fallbackPath = sourcePath || (app.workspace.getActiveFile()?.path ?? "");
+	if (!fallbackPath) {
+		return "";
+	}
 
-	const resetBtn = document.createElement("button");
-	resetBtn.className = "mermaid-toolbar-button";
-	resetBtn.setAttribute("aria-label", "Reset zoom");
-	setIcon(resetBtn, "rotate-cw");
-	resetBtn.addEventListener("click", (e) => {
-		e.preventDefault();
-		e.stopPropagation();
-		panZoomHandler.resetZoom();
-	});
-	zoomGroup.appendChild(resetBtn);
+	const sources = await getMermaidSourcesFromFile(app, fallbackPath);
+	const indexed = sources[index]?.trim();
+	if (indexed) {
+		return indexed;
+	}
 
-	const zoomOutBtn = document.createElement("button");
-	zoomOutBtn.className = "mermaid-toolbar-button";
-	zoomOutBtn.setAttribute("aria-label", "Zoom out");
-	setIcon(zoomOutBtn, "minus");
-	zoomOutBtn.addEventListener("click", (e) => {
-		e.preventDefault();
-		e.stopPropagation();
-		panZoomHandler.zoomOut();
-	});
-	zoomGroup.appendChild(zoomOutBtn);
-
-	toolbar.appendChild(zoomGroup);
-
-	// Export control group
-	const exportGroup = document.createElement("div");
-	exportGroup.className = "mermaid-toolbar-group";
-
-	const copyBtn = document.createElement("button");
-	copyBtn.className = "mermaid-toolbar-button";
-	copyBtn.setAttribute("aria-label", "Copy diagram code");
-	setIcon(copyBtn, "copy");
-	let resolvedSourceCode = sourceCode.trim();
-	copyBtn.addEventListener("click", (e) => {
-		e.preventDefault();
-		e.stopPropagation();
-		void (async () => {
-			if (!resolvedSourceCode) {
-				const containerSource = svg
-					.closest(".mermaid")
-					?.getAttribute("data-mermaid-source")
-					?.trim();
-				if (containerSource) {
-					resolvedSourceCode = containerSource;
-				}
-			}
-
-			if (!resolvedSourceCode) {
-				const fallbackPath = sourcePath || (app.workspace.getActiveFile()?.path ?? "");
-				if (fallbackPath) {
-					const sources = await getMermaidSourcesFromFile(app, fallbackPath);
-					const matchedSource = sources[index]?.trim();
-					if (matchedSource) {
-						resolvedSourceCode = matchedSource;
-					} else if (sources.length > 0) {
-						resolvedSourceCode = (sources[0] ?? "").trim();
-					}
-				}
-			}
-
-			if (!resolvedSourceCode) {
-				new Notice("Diagram code not available.");
-				return;
-			}
-
-			await navigator.clipboard.writeText(resolvedSourceCode);
-			new Notice("Diagram code copied to clipboard");
-			setIcon(copyBtn, "check");
-			setTimeout(() => setIcon(copyBtn, "copy"), 2000);
-		})().catch(() => {
-			new Notice("Unable to copy diagram code.");
-		});
-	});
-	exportGroup.appendChild(copyBtn);
-
-	const exportBtn = document.createElement("button");
-	exportBtn.className = "mermaid-toolbar-button";
-	exportBtn.setAttribute("aria-label", "Export diagram");
-	setIcon(exportBtn, "download");
-	exportBtn.addEventListener("click", (event) => {
-		event.preventDefault();
-		event.stopPropagation();
-		showExportMenu(event, svg, filename, settings);
-	});
-	exportGroup.appendChild(exportBtn);
-
-	toolbar.appendChild(exportGroup);
-
-	return toolbar;
+	return (sources[0] ?? "").trim();
 }
 
 /**
@@ -197,107 +247,128 @@ function showExportMenu(
 
 /**
  * Checks if an element is inside the standalone MermaidView.
- * We don't want to add toolbar/zoom there since it has its own controls.
  */
 function isInsideMermaidView(el: Element): boolean {
 	return el.closest(".mermaid-view-container") !== null;
 }
 
 /**
- * Adds pan/zoom and export functionality to a mermaid container element.
+ * Creates the embedded toolbar with zoom and export actions.
  */
-function addToolbarToMermaid(
+function createToolbar(
 	app: App,
 	mermaidEl: Element,
-	sourcePath: string,
-	index: number,
+	svg: SVGSVGElement,
+	filename: string,
 	settings: MermaidViewSettings,
-	sourceCode: string
-): void {
-	// Check if we've already processed this element
-	if (mermaidEl.classList.contains("mermaid-toolbar-processed")) {
-		return;
-	}
+	panZoomHandler: PanZoomHandler,
+	sourceCode: string,
+	sourcePath: string,
+	index: number
+): HTMLElement {
+	const toolbar = document.createElement("div");
+	toolbar.className = "mermaid-toolbar";
 
-	// Skip elements inside the standalone MermaidView (it has its own controls)
-	if (isInsideMermaidView(mermaidEl)) {
-		return;
-	}
+	const zoomGroup = document.createElement("div");
+	zoomGroup.className = "mermaid-toolbar-group";
 
-	const svg = mermaidEl.querySelector<SVGSVGElement>("svg");
-	if (!svg) {
-		return;
-	}
-
-	// Mark as processed
-	mermaidEl.classList.add("mermaid-toolbar-processed");
-
-	// Create main wrapper for the diagram
-	const wrapper = document.createElement("div");
-	wrapper.className = "mermaid-diagram-wrapper";
-	if (Platform.isMobile) {
-		wrapper.classList.add("is-mobile");
-	}
-
-	// Create zoom container (provides overflow: hidden)
-	const zoomContainer = document.createElement("div");
-	zoomContainer.className = "mermaid-zoom-container";
-
-	// Create zoom wrapper (receives transforms)
-	const zoomWrapper = document.createElement("div");
-	zoomWrapper.className = "mermaid-embedded-zoom-wrapper";
-
-	// Move the mermaid content into the zoom wrapper
-	const parent = mermaidEl.parentElement;
-	if (!parent) return;
-
-	parent.insertBefore(wrapper, mermaidEl);
-	zoomWrapper.appendChild(mermaidEl);
-	zoomContainer.appendChild(zoomWrapper);
-	wrapper.appendChild(zoomContainer);
-
-	// Create pan/zoom handler (disable wheel zoom to avoid scroll interference)
-	const panZoomHandler = new PanZoomHandler(zoomContainer, zoomWrapper, {
-		enableWheelZoom: false,
-		enableDragPan: true,
-		enableTouchGestures: true,
+	const zoomInBtn = document.createElement("button");
+	zoomInBtn.className = "mermaid-toolbar-button";
+	zoomInBtn.setAttribute("aria-label", "Zoom in");
+	setIcon(zoomInBtn, "plus");
+	zoomInBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		panZoomHandler.zoomIn();
 	});
+	zoomGroup.appendChild(zoomInBtn);
 
-	// Fit content to container after a brief delay to ensure layout is complete
-	requestAnimationFrame(() => {
-		panZoomHandler.fitContent();
+	const resetBtn = document.createElement("button");
+	resetBtn.className = "mermaid-toolbar-button";
+	resetBtn.setAttribute("aria-label", "Reset zoom");
+	setIcon(resetBtn, "rotate-cw");
+	resetBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		panZoomHandler.resetZoom();
 	});
+	zoomGroup.appendChild(resetBtn);
 
-	// Add toolbar with zoom controls and export button
-	const filename = generateFilename(sourcePath, index);
-	const toolbar = createToolbar(
-		app,
-		svg,
-		filename,
-		settings,
-		panZoomHandler,
-		sourceCode,
-		sourcePath,
-		index
-	);
-	wrapper.appendChild(toolbar);
+	const zoomOutBtn = document.createElement("button");
+	zoomOutBtn.className = "mermaid-toolbar-button";
+	zoomOutBtn.setAttribute("aria-label", "Zoom out");
+	setIcon(zoomOutBtn, "minus");
+	zoomOutBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		panZoomHandler.zoomOut();
+	});
+	zoomGroup.appendChild(zoomOutBtn);
+
+	toolbar.appendChild(zoomGroup);
+
+	const exportGroup = document.createElement("div");
+	exportGroup.className = "mermaid-toolbar-group";
+
+	const copyBtn = document.createElement("button");
+	copyBtn.className = "mermaid-toolbar-button";
+	copyBtn.setAttribute("aria-label", "Copy diagram code");
+	setIcon(copyBtn, "copy");
+	let resolvedSourceCode = sourceCode.trim();
+	copyBtn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		void (async () => {
+			resolvedSourceCode = await resolveSourceCode(
+				app,
+				mermaidEl,
+				resolvedSourceCode,
+				sourcePath,
+				index
+			);
+			if (!resolvedSourceCode) {
+				new Notice("Diagram code not available.");
+				return;
+			}
+
+			await navigator.clipboard.writeText(resolvedSourceCode);
+			new Notice("Diagram code copied to clipboard");
+			setIcon(copyBtn, "check");
+			setTimeout(() => setIcon(copyBtn, "copy"), 2000);
+		})().catch(() => {
+			new Notice("Unable to copy diagram code.");
+		});
+	});
+	exportGroup.appendChild(copyBtn);
+
+	const exportBtn = document.createElement("button");
+	exportBtn.className = "mermaid-toolbar-button";
+	exportBtn.setAttribute("aria-label", "Export diagram");
+	setIcon(exportBtn, "download");
+	exportBtn.addEventListener("click", (event) => {
+		event.preventDefault();
+		event.stopPropagation();
+		showExportMenu(event, svg, filename, settings);
+	});
+	exportGroup.appendChild(exportBtn);
+
+	toolbar.appendChild(exportGroup);
+
+	return toolbar;
 }
 
 /**
- * Waits for an SVG element to appear in a mermaid container.
- * Mermaid diagrams render asynchronously, so we need to observe for changes.
+ * Waits for Mermaid async rendering to produce an SVG element.
  */
 function waitForSvg(mermaidEl: Element, timeout = 5000): Promise<SVGSVGElement | null> {
 	return new Promise((resolve) => {
-		// Check if SVG already exists
 		const existingSvg = mermaidEl.querySelector<SVGSVGElement>("svg");
 		if (existingSvg) {
 			resolve(existingSvg);
 			return;
 		}
 
-		// Set up observer to wait for SVG
-		const observer = new MutationObserver((mutations, obs) => {
+		const observer = new MutationObserver((_, obs) => {
 			const svg = mermaidEl.querySelector<SVGSVGElement>("svg");
 			if (svg) {
 				obs.disconnect();
@@ -310,7 +381,6 @@ function waitForSvg(mermaidEl: Element, timeout = 5000): Promise<SVGSVGElement |
 			subtree: true,
 		});
 
-		// Timeout fallback
 		setTimeout(() => {
 			observer.disconnect();
 			resolve(mermaidEl.querySelector<SVGSVGElement>("svg"));
@@ -319,137 +389,83 @@ function waitForSvg(mermaidEl: Element, timeout = 5000): Promise<SVGSVGElement |
 }
 
 /**
- * Captures the mermaid source code from the element before SVG rendering
- * replaces the text content, with fallbacks for when SVG is already rendered.
+ * Adds zoom and export UI around a rendered Mermaid diagram.
  */
-function captureMermaidSource(mermaidEl: Element): string {
-	// Embed mode: source is preserved by EmbedHandler on the container element.
-	const embedContainer = mermaidEl.closest<HTMLElement>(".mermaid-embed");
-	if (embedContainer?.dataset.mermaidSource) {
-		return embedContainer.dataset.mermaidSource.trim();
+function addToolbarToMermaid(
+	app: App,
+	mermaidEl: Element,
+	sourcePath: string,
+	index: number,
+	settings: MermaidViewSettings,
+	sourceCode: string
+): void {
+	if (mermaidEl.classList.contains(MERMAID_TOOLBAR_PROCESSED_CLASS)) {
+		return;
 	}
 
-	// If SVG hasn't rendered yet, text content is the source
-	if (!mermaidEl.querySelector("svg")) {
-		return mermaidEl.textContent?.trim() ?? "";
+	if (isInsideMermaidView(mermaidEl)) {
+		return;
 	}
 
-	// Fallback: look for <code> element in parent block (Reading View)
-	const readingBlock = mermaidEl.closest(".el-pre, .block-language-mermaid");
-	if (readingBlock) {
-		const codeEl = readingBlock.querySelector("pre > code, code.language-mermaid, code");
-		if (codeEl?.textContent?.trim()) {
-			return codeEl.textContent.trim();
-		}
+	const svg = mermaidEl.querySelector<SVGSVGElement>("svg");
+	if (!svg) {
+		return;
 	}
 
-	// Fallback: extract from Live Preview code block structure
-	const cmBlock = mermaidEl.closest(".cm-preview-code-block");
-	if (cmBlock) {
-		const lines: string[] = [];
-		cmBlock.querySelectorAll(".cm-line").forEach((line) => {
-			lines.push(line.textContent ?? "");
-		});
-		if (lines.length > 0) {
-			return lines.join("\n").trim();
-		}
+	mermaidEl.classList.add(MERMAID_TOOLBAR_PROCESSED_CLASS);
+
+	const wrapper = document.createElement("div");
+	wrapper.className = "mermaid-diagram-wrapper";
+	if (Platform.isMobile) {
+		wrapper.classList.add("is-mobile");
 	}
 
-	return "";
-}
+	const zoomContainer = document.createElement("div");
+	zoomContainer.className = "mermaid-zoom-container";
 
-/**
- * Extracts mermaid source from a Live Preview code block container.
- */
-function captureSourceFromLivePreviewBlock(cmBlock: Element): string {
-	const lines: string[] = [];
-	cmBlock.querySelectorAll(".cm-line").forEach((line) => {
-		lines.push(line.textContent ?? "");
+	const zoomWrapper = document.createElement("div");
+	zoomWrapper.className = "mermaid-embedded-zoom-wrapper";
+
+	const parent = mermaidEl.parentElement;
+	if (!parent) {
+		return;
+	}
+
+	// Re-wrap Mermaid output so pan/zoom transforms are isolated from surrounding layout.
+	parent.insertBefore(wrapper, mermaidEl);
+	zoomWrapper.appendChild(mermaidEl);
+	zoomContainer.appendChild(zoomWrapper);
+	wrapper.appendChild(zoomContainer);
+
+	// Disable wheel zoom to avoid hijacking normal note scrolling.
+	const panZoomHandler = new PanZoomHandler(zoomContainer, zoomWrapper, {
+		enableWheelZoom: false,
+		enableDragPan: true,
+		enableTouchGestures: true,
 	});
 
-	if (lines.length === 0) {
-		return "";
-	}
+	// Fit after layout to get stable container dimensions.
+	requestAnimationFrame(() => {
+		panZoomHandler.fitContent();
+	});
 
-	// If fences are present, extract content inside ```mermaid ... ```
-	const fenced = extractMermaidBlocks(lines);
-	if (fenced.length > 0) {
-		return fenced[0] ?? "";
-	}
-
-	// Some Live Preview structures expose only block content lines.
-	return lines.join("\n").trim();
+	const filename = generateFilename(sourcePath, index);
+	const toolbar = createToolbar(
+		app,
+		mermaidEl,
+		svg,
+		filename,
+		settings,
+		panZoomHandler,
+		sourceCode,
+		sourcePath,
+		index
+	);
+	wrapper.appendChild(toolbar);
 }
 
 /**
- * Extracts mermaid code blocks from markdown lines.
- */
-function extractMermaidBlocks(lines: string[]): string[] {
-	const blocks: string[] = [];
-	let inMermaidBlock = false;
-	let currentBlock: string[] = [];
-
-	for (const line of lines) {
-		if (!inMermaidBlock) {
-			const fenceMatch = line.match(/^```([\w-]+)?\s*$/);
-			if (fenceMatch && fenceMatch[1]?.toLowerCase() === "mermaid") {
-				inMermaidBlock = true;
-				currentBlock = [];
-			}
-			continue;
-		}
-
-		if (/^```\s*$/.test(line)) {
-			blocks.push(currentBlock.join("\n").trim());
-			inMermaidBlock = false;
-			currentBlock = [];
-			continue;
-		}
-
-		currentBlock.push(line);
-	}
-
-	return blocks;
-}
-
-/**
- * Extracts mermaid source blocks from a markdown file.
- */
-async function getMermaidSourcesFromFile(app: App, sourcePath: string): Promise<string[]> {
-	const abstractFile = app.vault.getAbstractFileByPath(sourcePath);
-	if (!(abstractFile instanceof TFile)) {
-		return [];
-	}
-
-	const fileContent = await app.vault.read(abstractFile);
-	return extractMermaidBlocks(fileContent.split(/\r?\n/));
-}
-
-/**
- * Extracts mermaid source code from the current rendered section using source lines.
- */
-async function getMermaidSourcesFromSection(
-	app: App,
-	containerEl: HTMLElement,
-	ctx: MarkdownPostProcessorContext
-): Promise<string[]> {
-	const sectionInfo = ctx.getSectionInfo(containerEl);
-	if (!sectionInfo || !ctx.sourcePath) {
-		return [];
-	}
-
-	const abstractFile = app.vault.getAbstractFileByPath(ctx.sourcePath);
-	if (!(abstractFile instanceof TFile)) {
-		return [];
-	}
-	const fileContent = await app.vault.read(abstractFile);
-	const lines = fileContent.split(/\r?\n/);
-	const sectionLines = lines.slice(sectionInfo.lineStart, sectionInfo.lineEnd + 1);
-	return extractMermaidBlocks(sectionLines);
-}
-
-/**
- * Processes a mermaid element to add toolbar functionality.
+ * Coordinates source capture and delayed toolbar setup for one Mermaid node.
  */
 function processMermaidElement(
 	app: App,
@@ -459,16 +475,22 @@ function processMermaidElement(
 	settings: MermaidViewSettings,
 	fallbackSourceCode = ""
 ): void {
-	// Capture source code before SVG rendering replaces text content
+	if (processingMermaidElements.has(mermaidEl)) {
+		return;
+	}
+
 	const sourceCode = captureMermaidSource(mermaidEl) || fallbackSourceCode;
 	if (sourceCode) {
 		(mermaidEl as HTMLElement).dataset.mermaidSource = sourceCode;
 	}
 
+	processingMermaidElements.add(mermaidEl);
 	void waitForSvg(mermaidEl).then((svg) => {
 		if (svg) {
 			addToolbarToMermaid(app, mermaidEl, sourcePath, index, settings, sourceCode);
 		}
+		// Always clear the guard so future rerenders can be processed.
+		processingMermaidElements.delete(mermaidEl);
 	});
 }
 
@@ -524,17 +546,13 @@ export function createLivePreviewExportObserver(
 	let diagramCounter = 0;
 
 	const processElement = (el: Element): void => {
-		// Skip elements inside the standalone MermaidView (it has its own controls)
 		if (isInsideMermaidView(el)) {
 			return;
 		}
 
-		// Look for mermaid containers in Live Preview
-		// Structure: .cm-preview-code-block.cm-embed-block.cm-lang-mermaid > .mermaid > svg
 		if (el.matches?.(".cm-preview-code-block.cm-lang-mermaid")) {
 			const mermaidEl = el.querySelector(".mermaid");
-			if (mermaidEl && !mermaidEl.classList.contains("mermaid-toolbar-processed")) {
-				// Try to get source path from the active file
+			if (mermaidEl && !mermaidEl.classList.contains(MERMAID_TOOLBAR_PROCESSED_CLASS)) {
 				const sourcePath = app.workspace.getActiveFile()?.path ?? "";
 				const livePreviewSource = captureSourceFromLivePreviewBlock(el);
 				processMermaidElement(
@@ -548,19 +566,11 @@ export function createLivePreviewExportObserver(
 			}
 		}
 
-		// Also check for .mermaid elements directly (Reading View structure)
-		if (el.matches?.(".mermaid") && !el.classList.contains("mermaid-toolbar-processed")) {
+		if (el.matches?.(".mermaid") && !el.classList.contains(MERMAID_TOOLBAR_PROCESSED_CLASS)) {
 			const cmBlock = el.closest(".cm-preview-code-block.cm-lang-mermaid");
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
 			const livePreviewSource = cmBlock ? captureSourceFromLivePreviewBlock(cmBlock) : "";
-			processMermaidElement(
-				app,
-				el,
-				sourcePath,
-				diagramCounter++,
-				settings,
-				livePreviewSource
-			);
+			processMermaidElement(app, el, sourcePath, diagramCounter++, settings, livePreviewSource);
 		}
 	};
 
@@ -568,46 +578,31 @@ export function createLivePreviewExportObserver(
 		for (const mutation of mutations) {
 			for (const node of Array.from(mutation.addedNodes)) {
 				if (node instanceof HTMLElement) {
-					// Check the node itself
 					processElement(node);
-
-					// Check children for mermaid containers
-					const mermaidContainers = node.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid");
-					mermaidContainers.forEach(processElement);
-
-					// Also check for .mermaid elements directly
-					const mermaidElements = node.querySelectorAll(".mermaid");
-					mermaidElements.forEach(processElement);
+					node
+						.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid")
+						.forEach(processElement);
+					node.querySelectorAll(".mermaid").forEach(processElement);
 				}
 			}
 		}
 	});
 
-	// Observe the entire document
 	observer.observe(document.body, {
 		childList: true,
 		subtree: true,
 	});
 
-	// Process any existing mermaid diagrams (excluding those in standalone MermaidView)
 	document.querySelectorAll(".cm-preview-code-block.cm-lang-mermaid").forEach(processElement);
 	document.querySelectorAll(".mermaid:not(.mermaid-toolbar-processed)").forEach((el) => {
 		if (!isInsideMermaidView(el)) {
 			const cmBlock = el.closest(".cm-preview-code-block.cm-lang-mermaid");
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
 			const livePreviewSource = cmBlock ? captureSourceFromLivePreviewBlock(cmBlock) : "";
-			processMermaidElement(
-				app,
-				el,
-				sourcePath,
-				diagramCounter++,
-				settings,
-				livePreviewSource
-			);
+			processMermaidElement(app, el, sourcePath, diagramCounter++, settings, livePreviewSource);
 		}
 	});
 
-	// Return cleanup function
 	return () => {
 		observer.disconnect();
 	};


### PR DESCRIPTION
Provide a button to copy the source code of the chart. It works across all 3 different styles:

- Mermaid View
- Embedded in Markdown
- Embedded in code block (Obsidian)
