### PR TITLE
Bind the click directives of Mermaid diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 
 ## Unreleased
 
+### Added
+
+- Show the tooltip of a `click` directive when the pointer stays over the node (#72).
+
+### Fixed
+
+- Open the links of `click` directives in diagram types that Obsidian leaves inert, such as gantt (#58).
+- Keep a click on a link a click: a pointer movement now has to pass a small threshold before it counts as a pan.
+
 ## 0.6.1 - 2026-05-16
 
 ### Added

--- a/src/MermaidView.ts
+++ b/src/MermaidView.ts
@@ -11,6 +11,8 @@ import { EditorState } from "@codemirror/state";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import type MermaidViewPlugin from "./main";
 import { exportAsSvg, exportAsPng } from "./export";
+import { bindMermaidFunctions } from "./mermaidBindings";
+import { waitForSvg } from "./mermaidDom";
 import { PanZoomHandler } from "./panZoom";
 
 export const VIEW_TYPE_MERMAID = "mermaid-view";
@@ -273,7 +275,11 @@ export class MermaidView extends TextFileView {
 				cls: "mermaid-view-error",
 				text: `Error rendering diagram:\n${String(error)}`,
 			});
+			return;
 		}
+
+		const svg = await waitForSvg(wrapper);
+		if (svg) bindMermaidFunctions(svg, content);
 	}
 
 	private updateZoomIndicator(scale: number, translateX: number, translateY: number): void {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -1,4 +1,6 @@
 import { App, Component, MarkdownRenderer, TFile } from "obsidian";
+import { bindMermaidFunctions } from "./mermaidBindings";
+import { waitForSvg } from "./mermaidDom";
 
 /**
  * Handles rendering of embedded mermaid files in notes.
@@ -105,14 +107,14 @@ export class EmbedHandler {
 
 		if (!linkedFile) return;
 
-		const content = await this.app.vault.read(linkedFile);
+		const content = (await this.app.vault.read(linkedFile)).trim();
 
 		// Mark as processed and update classes
 		container.empty();
 		container.addClass("mermaid-embed");
 		container.removeClass("file-embed", "mod-generic");
 
-		const mermaidMarkdown = "```mermaid\n" + content.trim() + "\n```";
+		const mermaidMarkdown = "```mermaid\n" + content + "\n```";
 
 		const embedComponent = new Component();
 		addChild(embedComponent);
@@ -125,5 +127,8 @@ export class EmbedHandler {
 			linkedFile.path,
 			embedComponent
 		);
+
+		const svg = await waitForSvg(container);
+		if (svg) bindMermaidFunctions(svg, content);
 	}
 }

--- a/src/markdownExport.ts
+++ b/src/markdownExport.ts
@@ -1,5 +1,7 @@
 import { App, MarkdownPostProcessorContext, Menu, Platform, setIcon } from "obsidian";
 import { exportAsSvg, exportAsPng } from "./export";
+import { bindMermaidFunctions, extractMermaidBlocks } from "./mermaidBindings";
+import { waitForSvg } from "./mermaidDom";
 import { PanZoomHandler } from "./panZoom";
 import type { MermaidViewSettings, PngBackground } from "./settings";
 
@@ -157,25 +159,11 @@ function isInsideMermaidView(el: Element): boolean {
  */
 function addToolbarToMermaid(
 	mermaidEl: Element,
+	svg: SVGSVGElement,
 	sourcePath: string,
 	index: number,
 	settings: MermaidViewSettings
 ): void {
-	// Check if we've already processed this element
-	if (mermaidEl.classList.contains("mermaid-toolbar-processed")) {
-		return;
-	}
-
-	// Skip elements inside the standalone MermaidView (it has its own controls)
-	if (isInsideMermaidView(mermaidEl)) {
-		return;
-	}
-
-	const svg = mermaidEl.querySelector<SVGSVGElement>("svg");
-	if (!svg) {
-		return;
-	}
-
 	// Mark as processed
 	mermaidEl.classList.add("mermaid-toolbar-processed");
 
@@ -222,53 +210,36 @@ function addToolbarToMermaid(
 }
 
 /**
- * Waits for an SVG element to appear in a mermaid container.
- * Mermaid diagrams render asynchronously, so we need to observe for changes.
+ * Reads the diagram sources of a note. A note can hold more than one diagram, so this
+ * returns all of them. A `click` directive applies only to the diagram that holds a node
+ * of the same id.
  */
-function waitForSvg(mermaidEl: Element, timeout = 5000): Promise<SVGSVGElement | null> {
-	return new Promise((resolve) => {
-		// Check if SVG already exists
-		const existingSvg = mermaidEl.querySelector<SVGSVGElement>("svg");
-		if (existingSvg) {
-			resolve(existingSvg);
-			return;
-		}
+async function readDiagramSources(app: App, sourcePath: string): Promise<string> {
+	const file = app.vault.getFileByPath(sourcePath);
+	if (!file) return "";
 
-		// Set up observer to wait for SVG
-		const observer = new MutationObserver((mutations, obs) => {
-			const svg = mermaidEl.querySelector<SVGSVGElement>("svg");
-			if (svg) {
-				obs.disconnect();
-				resolve(svg);
-			}
-		});
-
-		observer.observe(mermaidEl, {
-			childList: true,
-			subtree: true,
-		});
-
-		// Timeout fallback
-		mermaidEl.win.setTimeout(() => {
-			observer.disconnect();
-			resolve(mermaidEl.querySelector<SVGSVGElement>("svg"));
-		}, timeout);
-	});
+	return extractMermaidBlocks(await app.vault.cachedRead(file));
 }
 
 /**
- * Processes a mermaid element to add toolbar functionality.
+ * Processes a mermaid element to add toolbar functionality and the `click` directives.
  */
 function processMermaidElement(
+	app: App,
 	mermaidEl: Element,
 	sourcePath: string,
 	index: number,
 	settings: MermaidViewSettings
 ): void {
-	void waitForSvg(mermaidEl).then((svg) => {
-		if (svg) {
-			addToolbarToMermaid(mermaidEl, sourcePath, index, settings);
-		}
+	void waitForSvg(mermaidEl).then(async (svg) => {
+		if (!svg) return;
+
+		// Skip elements inside the standalone MermaidView (it has its own controls)
+		if (isInsideMermaidView(mermaidEl)) return;
+		if (mermaidEl.classList.contains("mermaid-toolbar-processed")) return;
+
+		addToolbarToMermaid(mermaidEl, svg, sourcePath, index, settings);
+		bindMermaidFunctions(svg, await readDiagramSources(app, sourcePath));
 	});
 }
 
@@ -285,7 +256,7 @@ export function registerMermaidExportPostProcessor(
 		const mermaidElements = el.querySelectorAll(".mermaid");
 
 		mermaidElements.forEach((mermaidEl, index) => {
-			processMermaidElement(mermaidEl, ctx.sourcePath, index, settings);
+			processMermaidElement(app, mermaidEl, ctx.sourcePath, index, settings);
 		});
 	});
 }
@@ -313,14 +284,14 @@ export function createLivePreviewExportObserver(
 			if (mermaidEl && !mermaidEl.classList.contains("mermaid-toolbar-processed")) {
 				// Try to get source path from the active file
 				const sourcePath = app.workspace.getActiveFile()?.path ?? "";
-				processMermaidElement(mermaidEl, sourcePath, diagramCounter++, settings);
+				processMermaidElement(app, mermaidEl, sourcePath, diagramCounter++, settings);
 			}
 		}
 
 		// Also check for .mermaid elements directly (Reading View structure)
 		if (el.matches?.(".mermaid") && !el.classList.contains("mermaid-toolbar-processed")) {
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
-			processMermaidElement(el, sourcePath, diagramCounter++, settings);
+			processMermaidElement(app, el, sourcePath, diagramCounter++, settings);
 		}
 	};
 
@@ -354,7 +325,7 @@ export function createLivePreviewExportObserver(
 	activeDocument.querySelectorAll(".mermaid:not(.mermaid-toolbar-processed)").forEach((el) => {
 		if (!isInsideMermaidView(el)) {
 			const sourcePath = app.workspace.getActiveFile()?.path ?? "";
-			processMermaidElement(el, sourcePath, diagramCounter++, settings);
+			processMermaidElement(app, el, sourcePath, diagramCounter++, settings);
 		}
 	});
 

--- a/src/mermaidBindings.test.ts
+++ b/src/mermaidBindings.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { extractMermaidBlocks, parseMermaidLinks } from "./mermaidBindings";
+
+describe("parseMermaidLinks", () => {
+	it("parses a click directive with the href keyword", () => {
+		expect(parseMermaidLinks('click des1 href "https://google.com/"')).toEqual([
+			{ id: "des1", url: "https://google.com/" },
+		]);
+	});
+
+	it("parses a click directive without the href keyword", () => {
+		expect(parseMermaidLinks('click des1 "https://google.com/"')).toEqual([
+			{ id: "des1", url: "https://google.com/" },
+		]);
+	});
+
+	it("parses a directive that lists several ids", () => {
+		expect(parseMermaidLinks('click des1,des2 href "https://google.com/"')).toEqual([
+			{ id: "des1", url: "https://google.com/" },
+			{ id: "des2", url: "https://google.com/" },
+		]);
+	});
+
+	it("keeps the indentation of the directive out of the id", () => {
+		expect(parseMermaidLinks('    click des1 href "https://google.com/"')).toEqual([
+			{ id: "des1", url: "https://google.com/" },
+		]);
+	});
+
+	it("parses every directive of a diagram", () => {
+		const source = [
+			"gantt",
+			"    title Project Tasks",
+			"    section Project Alpha",
+			"        Sample Task 1 :milestone, des1, 2026-04-16, 0d",
+			"",
+			'click des1 href "https://google.com/"',
+			'click des2 href "https://www.google.com/maps"',
+		].join("\n");
+
+		expect(parseMermaidLinks(source)).toEqual([
+			{ id: "des1", url: "https://google.com/" },
+			{ id: "des2", url: "https://www.google.com/maps" },
+		]);
+	});
+
+	it("ignores a directive that calls a function", () => {
+		expect(parseMermaidLinks('click des1 call myCallback("arg")')).toEqual([]);
+	});
+
+	it("ignores a tooltip that follows the url", () => {
+		expect(parseMermaidLinks('click des1 href "https://google.com/" "A tooltip"')).toEqual([
+			{ id: "des1", url: "https://google.com/" },
+		]);
+	});
+
+	it("ignores a line that does not start with click", () => {
+		expect(parseMermaidLinks('A --> B: click des1 href "https://google.com/"')).toEqual([]);
+	});
+
+	it("rejects a javascript url", () => {
+		expect(parseMermaidLinks('click des1 href "javascript:alert(1)"')).toEqual([]);
+	});
+
+	it("rejects a javascript url that contains a control character", () => {
+		expect(parseMermaidLinks('click des1 href "java\tscript:alert(1)"')).toEqual([]);
+	});
+
+	it("rejects a data url", () => {
+		expect(parseMermaidLinks('click des1 href "data:text/html,<script></script>"')).toEqual([]);
+	});
+
+	it("rejects a relative url", () => {
+		expect(parseMermaidLinks('click des1 href "notes/diagram.md"')).toEqual([]);
+	});
+
+	it("accepts a mailto url", () => {
+		expect(parseMermaidLinks('click des1 href "mailto:someone@example.com"')).toEqual([
+			{ id: "des1", url: "mailto:someone@example.com" },
+		]);
+	});
+
+	it("accepts an obsidian url", () => {
+		expect(parseMermaidLinks('click des1 href "obsidian://open?vault=Notes"')).toEqual([
+			{ id: "des1", url: "obsidian://open?vault=Notes" },
+		]);
+	});
+
+	it("handles a source without directives", () => {
+		expect(parseMermaidLinks("flowchart LR\n  A --> B\n")).toEqual([]);
+	});
+
+	it("handles an empty source", () => {
+		expect(parseMermaidLinks("")).toEqual([]);
+	});
+});
+
+describe("extractMermaidBlocks", () => {
+	it("extracts the source of a fenced mermaid block", () => {
+		const note = "# Note\n\n```mermaid\nflowchart LR\n  A --> B\n```\n";
+
+		expect(extractMermaidBlocks(note).trim()).toBe("flowchart LR\n  A --> B");
+	});
+
+	it("ignores a fenced block of another language", () => {
+		const note = '```js\nclick des1 href "https://example.com/"\n```\n';
+
+		expect(extractMermaidBlocks(note)).toBe("");
+	});
+
+	it("extracts every block of a note", () => {
+		const note =
+			'```mermaid\nflowchart LR\nclick a href "https://a.example/"\n```\n\n' +
+			'```mermaid\nflowchart LR\nclick b href "https://b.example/"\n```\n';
+
+		expect(parseMermaidLinks(extractMermaidBlocks(note))).toEqual([
+			{ id: "a", url: "https://a.example/" },
+			{ id: "b", url: "https://b.example/" },
+		]);
+	});
+
+	it("extracts a block that is indented in a list item", () => {
+		const note = '- item\n\n\t```mermaid\n\tflowchart LR\n\tclick a href "https://a.example/"\n\t```\n';
+
+		expect(parseMermaidLinks(extractMermaidBlocks(note))).toEqual([
+			{ id: "a", url: "https://a.example/" },
+		]);
+	});
+
+	it("extracts a block that uses more than three backticks", () => {
+		const note = '````mermaid\nflowchart LR\nclick a href "https://a.example/"\n````\n';
+
+		expect(parseMermaidLinks(extractMermaidBlocks(note))).toEqual([
+			{ id: "a", url: "https://a.example/" },
+		]);
+	});
+
+	it("handles a note without a mermaid block", () => {
+		expect(extractMermaidBlocks("# Note\n\nSome text.\n")).toBe("");
+	});
+
+	it("handles an empty note", () => {
+		expect(extractMermaidBlocks("")).toBe("");
+	});
+
+	it("extracts the gantt diagram of the reported note", () => {
+		const note = [
+			"The following diagram in an obsidian note that has clickable tasks:",
+			"",
+			"```mermaid",
+			"gantt",
+			"    title Project Tasks",
+			"    dateFormat YYYY-MM-DD",
+			"",
+			"    section Project Alpha",
+			"        Sample Task 1 :milestone, des1, 2026-04-16, 0d",
+			"",
+			'click des1 href "https://google.com/"',
+			'click des2 href "https://www.google.com/maps"',
+			"```",
+			"",
+		].join("\n");
+
+		expect(parseMermaidLinks(extractMermaidBlocks(note))).toEqual([
+			{ id: "des1", url: "https://google.com/" },
+			{ id: "des2", url: "https://www.google.com/maps" },
+		]);
+	});
+});

--- a/src/mermaidBindings.ts
+++ b/src/mermaidBindings.ts
@@ -1,0 +1,117 @@
+/**
+ * A link declared by a `click` directive in the diagram source.
+ */
+interface MermaidLink {
+	/** The node or task id, as written in the directive. */
+	id: string;
+	url: string;
+}
+
+// Matches `click <ids> href "<url>"` and the short form `click <ids> "<url>"`.
+const CLICK_DIRECTIVE = /^[ \t]*click[ \t]+([^\s"]+)[ \t]+(?:href[ \t]+)?"([^"]+)"/;
+
+const SAFE_PROTOCOLS = ["http:", "https:", "mailto:", "obsidian:"];
+
+/**
+ * Extracts the link targets from the `click` directives of a diagram source.
+ */
+export function parseMermaidLinks(source: string): MermaidLink[] {
+	const links: MermaidLink[] = [];
+
+	for (const line of source.split("\n")) {
+		const match = CLICK_DIRECTIVE.exec(line);
+		if (!match) continue;
+
+		const ids = match[1];
+		const url = match[2];
+		if (!ids || !url || !isSafeUrl(url)) continue;
+
+		for (const id of ids.split(",")) {
+			const trimmed = id.trim();
+			if (trimmed) links.push({ id: trimmed, url });
+		}
+	}
+
+	return links;
+}
+
+/**
+ * Extracts the diagram sources from the fenced mermaid blocks of a note.
+ */
+export function extractMermaidBlocks(markdown: string): string {
+	// The fence can hold more than three backticks, so the closing fence matches the opening one.
+	const block = /^[ \t]*(`{3,})[ \t]*mermaid[^\n]*\n([\s\S]*?)^[ \t]*\1/gm;
+	const sources: string[] = [];
+
+	let match = block.exec(markdown);
+	while (match !== null) {
+		if (match[2]) sources.push(match[2]);
+		match = block.exec(markdown);
+	}
+
+	return sources.join("\n");
+}
+
+/**
+ * Applies the interactions of the `click` directives to a rendered diagram.
+ *
+ * Obsidian renders Mermaid without the `bindFunctions` callback of the renderer, so the
+ * links and the tooltips that Mermaid installs from that callback never reach the diagram.
+ */
+export function bindMermaidFunctions(svg: SVGSVGElement, source: string): void {
+	bindLinks(svg, source);
+	bindTooltips(svg);
+}
+
+/**
+ * Opens the link of a node on click.
+ * Diagram types that render an `<a>` element (flowchart) are left to Obsidian.
+ */
+function bindLinks(svg: SVGSVGElement, source: string): void {
+	for (const link of parseMermaidLinks(source)) {
+		for (const el of findLinkTargets(svg, link.id)) {
+			if (el.closest("a")) continue;
+
+			el.addEventListener("click", (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				svg.win.open(link.url, "_blank");
+			});
+		}
+	}
+}
+
+/**
+ * Shows the tooltip of a node on hover.
+ * Mermaid keeps the tooltip in a `title` attribute, which SVG does not display.
+ */
+function bindTooltips(svg: SVGSVGElement): void {
+	for (const el of Array.from(svg.querySelectorAll("[title]"))) {
+		const tooltip = el.getAttribute("title");
+		if (!tooltip || el.querySelector(":scope > title")) continue;
+
+		el.createSvg("title", { prepend: true }).textContent = tooltip;
+	}
+}
+
+/**
+ * Finds the diagram elements that a `click` directive applies to.
+ * Mermaid gives the shape the id of the node, and the label the same id with a `-text` suffix.
+ */
+function findLinkTargets(svg: SVGSVGElement, id: string): Element[] {
+	const shape = CSS.escape(id);
+	const label = CSS.escape(`${id}-text`);
+	return Array.from(svg.querySelectorAll(`#${shape}, #${label}`));
+}
+
+/**
+ * Accepts absolute URLs of a known scheme only. The URL parser normalizes the scheme
+ * the same way the browser does, so obfuscated `javascript:` URLs cannot pass.
+ */
+function isSafeUrl(url: string): boolean {
+	try {
+		return SAFE_PROTOCOLS.includes(new URL(url).protocol);
+	} catch {
+		return false;
+	}
+}

--- a/src/mermaidDom.ts
+++ b/src/mermaidDom.ts
@@ -1,0 +1,35 @@
+/**
+ * Waits for an SVG element to appear in a mermaid container.
+ * Mermaid diagrams render asynchronously, so we need to observe for changes.
+ */
+export function waitForSvg(container: Element, timeout = 5000): Promise<SVGSVGElement | null> {
+	return new Promise((resolve) => {
+		// Check if SVG already exists
+		const existingSvg = container.querySelector<SVGSVGElement>("svg");
+		if (existingSvg) {
+			resolve(existingSvg);
+			return;
+		}
+
+		// Set up observer to wait for SVG
+		const observer = new MutationObserver((mutations, obs) => {
+			const svg = container.querySelector<SVGSVGElement>("svg");
+			if (svg) {
+				obs.disconnect();
+				container.win.clearTimeout(timer);
+				resolve(svg);
+			}
+		});
+
+		observer.observe(container, {
+			childList: true,
+			subtree: true,
+		});
+
+		// Timeout fallback
+		const timer = container.win.setTimeout(() => {
+			observer.disconnect();
+			resolve(container.querySelector<SVGSVGElement>("svg"));
+		}, timeout);
+	});
+}

--- a/src/panZoom.ts
+++ b/src/panZoom.ts
@@ -32,6 +32,11 @@ export class PanZoomHandler {
 	private didPan = false; // Track if actual movement occurred
 	private startX = 0;
 	private startY = 0;
+	private downX = 0;
+	private downY = 0;
+
+	// A click keeps its default action below this distance, so links stay clickable.
+	private static readonly PAN_THRESHOLD_PX = 3;
 
 	private readonly minScale: number;
 	private readonly maxScale: number;
@@ -192,14 +197,15 @@ export class PanZoomHandler {
 				this.didPan = false; // Reset pan tracking
 				this.startX = e.clientX - this.translateX;
 				this.startY = e.clientY - this.translateY;
-				this.container.classList.add("mermaid-view-panning");
+				this.downX = e.clientX;
+				this.downY = e.clientY;
 			};
 			this.container.addEventListener("mousedown", handleMouseDown);
 			this.cleanupFns.push(() => this.container.removeEventListener("mousedown", handleMouseDown));
 
 			const handleMouseMove = (e: MouseEvent): void => {
 				if (!this.isPanning) return;
-				this.didPan = true; // Actual movement occurred
+				if (!this.startPan(e.clientX, e.clientY)) return;
 				this.translateX = e.clientX - this.startX;
 				this.translateY = e.clientY - this.startY;
 				this.applyTransform();
@@ -259,7 +265,8 @@ export class PanZoomHandler {
 					this.didPan = false; // Reset pan tracking
 					this.startX = touch1.clientX - this.translateX;
 					this.startY = touch1.clientY - this.translateY;
-					this.container.classList.add("mermaid-view-panning");
+					this.downX = touch1.clientX;
+					this.downY = touch1.clientY;
 				}
 			};
 			this.container.addEventListener("touchstart", handleTouchStart);
@@ -298,7 +305,7 @@ export class PanZoomHandler {
 					this.applyTransform();
 				} else if (e.touches.length === 1 && touch1 && this.isPanning) {
 					// Single touch pan
-					this.didPan = true;
+					if (!this.startPan(touch1.clientX, touch1.clientY)) return;
 					this.translateX = touch1.clientX - this.startX;
 					this.translateY = touch1.clientY - this.startY;
 					this.applyTransform();
@@ -314,6 +321,22 @@ export class PanZoomHandler {
 			this.container.addEventListener("touchend", handleTouchEnd);
 			this.cleanupFns.push(() => this.container.removeEventListener("touchend", handleTouchEnd));
 		}
+	}
+
+	/**
+	 * Starts the pan when the pointer passes the threshold.
+	 * Returns true when the pan is active.
+	 */
+	private startPan(clientX: number, clientY: number): boolean {
+		if (!this.didPan) {
+			const distance = Math.hypot(clientX - this.downX, clientY - this.downY);
+			if (distance <= PanZoomHandler.PAN_THRESHOLD_PX) return false;
+
+			this.didPan = true;
+			this.container.classList.add("mermaid-view-panning");
+		}
+
+		return true;
 	}
 
 	private applyTransform(): void {


### PR DESCRIPTION
Obsidian renders Mermaid without the `bindFunctions` callback of the renderer, so the links and the tooltips of a `click` directive never reach the diagram. This change adds a shim that reads the directives from the diagram source and applies the behaviour after the render, in the standalone view, in file embeds, and in the fenced blocks of a note. It also makes a drag count as a pan only after a small pointer movement, because the pan handler cancelled the click on a link.

Note: a note that holds two diagrams with the same node id and different URLs applies the first URL to both diagrams. To separate them, the code must map each diagram back to its own block. This needs the post-processor context in Reading View and the editor position in Live Preview.

Closes #58
