### PR TITLE
Show the Mermaid tooltip on the label of a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is
 
 ### Added
 
-- Show the tooltip of a `click` directive when the pointer stays over the node (#72).
+- Show the tooltip of a `click` directive when the pointer is over the node (#72).
 
 ### Fixed
 

--- a/src/mermaidBindings.ts
+++ b/src/mermaidBindings.ts
@@ -1,3 +1,5 @@
+import { setTooltip } from "obsidian";
+
 /**
  * A link declared by a `click` directive in the diagram source.
  */
@@ -91,6 +93,12 @@ function bindTooltips(svg: SVGSVGElement): void {
 		if (!tooltip || el.querySelector(":scope > title")) continue;
 
 		el.createSvg("title", { prepend: true }).textContent = tooltip;
+
+		// Mermaid draws the label of a node as HTML in a `foreignObject`, which covers most
+		// of the node. The Obsidian tooltip shows there without the delay of the SVG title.
+		for (const label of Array.from(el.querySelectorAll<HTMLElement>("foreignObject > div"))) {
+			setTooltip(label, tooltip);
+		}
 	}
 }
 

--- a/test/mocks/obsidian.ts
+++ b/test/mocks/obsidian.ts
@@ -1,3 +1,4 @@
 export class App {}
+export function setTooltip(): void {}
 export class PluginSettingTab {}
 export class Setting {}


### PR DESCRIPTION
Mermaid draws the label of a flowchart node as HTML in a `foreignObject`, and the label covers most of the node. The SVG `<title>` element from #106 does not apply to that area, so the tooltip stayed hidden where the pointer usually rests. This change also sets the Obsidian tooltip on the label element, and keeps the SVG `<title>` for the rest of the node and for the exported file.

Follows #106. Fixes #72.
